### PR TITLE
Edit Button and Nav Bar (left) refactor from grommet

### DIFF
--- a/matico_components/src/Components/MaticoEditor/Utils/EditButton.tsx
+++ b/matico_components/src/Components/MaticoEditor/Utils/EditButton.tsx
@@ -42,11 +42,13 @@ import Settings from "@spectrum-icons/workflow/Settings";
 interface EditButtonProps {
   editPath: string;
   editType: string;
+  sideEffect: Function;
 }
 
 export const EditButton: React.FC<EditButtonProps> = ({
   editPath,
   editType,
+  sideEffect=()=>{},
 }) => {
   const dispatch = useMaticoDispatch();
   const edit = useIsEditable();
@@ -54,18 +56,15 @@ export const EditButton: React.FC<EditButtonProps> = ({
   return (
     <Button
       variant="primary"
-      marginBottom="-50px"
-      position="absolute"
-      right="0"
-      top="0"
-      onPress={() =>
+      onPress={() => {
         dispatch(
           setCurrentEditPath({
             editPath,
             editType,
           })
-        )
-      }
+        );
+        sideEffect();
+      }}
       isQuiet
     >
       <Settings aria-label="Edit" color="notice" />

--- a/matico_components/src/Components/MaticoEditor/Utils/EditButton.tsx
+++ b/matico_components/src/Components/MaticoEditor/Utils/EditButton.tsx
@@ -1,9 +1,43 @@
+// import React from "react";
+// import { Box, Button } from "grommet";
+// import { setCurrentEditPath } from "Stores/MaticoSpecSlice";
+// import { useMaticoDispatch } from "Hooks/redux";
+// import { useIsEditable } from "Hooks/useIsEditable";
+// import { Performance } from "grommet-icons";
+
+// interface EditButtonProps {
+//   editPath: string;
+//   editType: string;
+// }
+
+// export const EditButton: React.FC<EditButtonProps> = ({
+//   editPath,
+//   editType,
+// }) => {
+//   const dispatch = useMaticoDispatch();
+//   const edit = useIsEditable();
+//   if (!edit) return null;
+//   return (
+//     <Button
+//       onClick={() =>
+//         dispatch(
+//           setCurrentEditPath({
+//             editPath,
+//             editType,
+//           })
+//         )
+//       }
+//       icon={<Performance color="accent-4" />}
+//     />
+//   );
+// };
+
 import React from "react";
-import { Box, Button } from "grommet";
+import { Button } from "@adobe/react-spectrum";
 import { setCurrentEditPath } from "Stores/MaticoSpecSlice";
 import { useMaticoDispatch } from "Hooks/redux";
 import { useIsEditable } from "Hooks/useIsEditable";
-import { Performance } from "grommet-icons";
+import Settings from "@spectrum-icons/workflow/Settings";
 
 interface EditButtonProps {
   editPath: string;
@@ -19,7 +53,12 @@ export const EditButton: React.FC<EditButtonProps> = ({
   if (!edit) return null;
   return (
     <Button
-      onClick={() =>
+      variant="primary"
+      marginBottom="-50px"
+      position="absolute"
+      right="0"
+      top="0"
+      onPress={() =>
         dispatch(
           setCurrentEditPath({
             editPath,
@@ -27,7 +66,9 @@ export const EditButton: React.FC<EditButtonProps> = ({
           })
         )
       }
-      icon={<Performance color="accent-4" />}
-    />
+      isQuiet
+    >
+      <Settings aria-label="Edit" color="notice" />
+    </Button>
   );
 };

--- a/matico_components/src/Components/MaticoNavBar/MaticoNavBar.tsx
+++ b/matico_components/src/Components/MaticoNavBar/MaticoNavBar.tsx
@@ -1,5 +1,6 @@
-import { Avatar, Box, Text, Button, Nav, Sidebar } from "grommet";
-import { Link } from "react-router-dom";
+import { Avatar, Box, Button, Nav, Sidebar } from "grommet";
+import { Link, Text, View } from "@adobe/react-spectrum";
+import { Link as RouterLink } from "react-router-dom";
 import { Page } from "@maticoapp/matico_spec";
 import React from "react";
 import * as Icons from "grommet-icons";
@@ -70,7 +71,7 @@ export const MaticoNavBar: React.FC<MaticoNavBarProps> = ({ pages }) => {
   return (
     <Sidebar
       background={chromaColor ? chromaColor.hex() : "neutral-2"}
-      style={{textAlign:'center'}}
+      style={{ textAlign: "center" }}
       header={
         <Avatar
           src={logo ?? "https://www.matico.app/favicon/favicon-32x32.png"}
@@ -81,29 +82,25 @@ export const MaticoNavBar: React.FC<MaticoNavBarProps> = ({ pages }) => {
       elevation="medium"
       footer={<Button icon={<Icons.Help />} hoverIndicator />}
     >
-      <Nav gap="small" >
+      <Nav gap="small">
         {pages.map((page, index) => (
-          <Link
-            style={{ textDecoration: "none" }}
-            key={page.name}
-            to={page.path ? page.path : `/${page.name}`}
-          >
-            <Button
-              badge={
-                <EditButton editPath={`pages.${index}`} editType={"Page"} />
-              }
-              a11yTitle={page.name}
-              icon={<NamedButton name={page.icon} />}
-              hoverIndicator
-            />
-            <Text
-              color="white"
-              size={"small"}
-              style={{ textDecoration: "none" }}
-            >
-              {page.name}
-            </Text>
-          </Link>
+          <View position="relative">
+            <EditButton editPath={`pages.${index}`} editType={"Page"} />
+            <Link isQuiet variant="secondary">
+              <RouterLink
+                style={{ textDecoration: "none" }}
+                key={page.name}
+                to={page.path ? page.path : `/${page.name}`}
+              >
+                <Button
+                  a11yTitle={page.name}
+                  icon={<NamedButton name={page.icon} />}
+                  hoverIndicator
+                />
+                <Text>{page.name}</Text>
+              </RouterLink>
+            </Link>
+          </View>
         ))}
         {editable && (
           <Button

--- a/matico_components/src/Components/MaticoNavBar/MaticoNavBar.tsx
+++ b/matico_components/src/Components/MaticoNavBar/MaticoNavBar.tsx
@@ -1,6 +1,6 @@
 import { Avatar, Box, Button, Nav, Sidebar } from "grommet";
 import { Link, Text, View } from "@adobe/react-spectrum";
-import { Link as RouterLink } from "react-router-dom";
+import { Link as RouterLink, useHistory } from "react-router-dom";
 import { Page } from "@maticoapp/matico_spec";
 import React from "react";
 import * as Icons from "grommet-icons";
@@ -22,8 +22,9 @@ const NamedButton: React.FC<{ name: string; color?: string; size?: string }> =
 
 export const MaticoNavBar: React.FC<MaticoNavBarProps> = ({ pages }) => {
   const editable = useIsEditable();
-  const dispatch = useMaticoDispatch();
+  const dispatch = useMaticoDispatch(); 
   const theme = useMaticoSelector((state) => state.spec.spec.theme);
+  const history = useHistory();
   const primaryColor = theme?.primaryColor;
   const logo = theme?.logoUrl;
 
@@ -85,7 +86,9 @@ export const MaticoNavBar: React.FC<MaticoNavBarProps> = ({ pages }) => {
       <Nav gap="small">
         {pages.map((page, index) => (
           <View position="relative">
-            <EditButton editPath={`pages.${index}`} editType={"Page"} />
+            <View position="absolute" top="0" right="-25%">
+              <EditButton editPath={`pages.${index}`} editType={"Page"} sideEffect={() => history.push(page.path ? page.path : `/${page.name}`)} />
+            </View>
             <Link isQuiet variant="secondary">
               <RouterLink
                 style={{ textDecoration: "none" }}


### PR DESCRIPTION
- Swaps edit button to spectrum
- Adds `sideEffect` prop for navigating while clicking to edit, or any arbitrary function
- Changes left nav bar to Spectrum links and buttons, etc.