### PR TITLE
Performance tweak to only calculate column stats when column tab is open

### DIFF
--- a/matico_admin/components/ColumnDetails.tsx
+++ b/matico_admin/components/ColumnDetails.tsx
@@ -8,7 +8,7 @@ import {
   Grid,
 } from "@adobe/react-spectrum";
 import MoreVertical from "@spectrum-icons/workflow/MoreSmallListVert";
-import React from "react";
+import React, {useState} from "react";
 import { useColumnStat } from "../hooks/useColumnStat";
 import { useDatasetColumn } from "../hooks/useDatasetColumns";
 import { Source } from "../hooks/useTableData";
@@ -23,8 +23,6 @@ const statForDataType = (dataType: any) => {
   const histogram = { Histogram: { no_bins: 20 } };
   const categories = { ValueCounts: {} };
 
-  console.log("Data type is ",dataType)
-  
   switch (dataType) {
     case "INT4":
       return histogram;
@@ -90,25 +88,25 @@ export const ColumnDetails: React.FC<ColumnDetailProps> = ({
   source,
   colName,
 }) => {
+  const [isOpen, setIsOpen] = useState(false)
   const { column , columnError} = useDatasetColumn(source, colName);
 
   const stat = statForDataType(column?.col_type);
   const { data: dataSummary, error: dataSummaryError } = useColumnStat(
-    source,
+    isOpen ? source : null,
     colName,
     stat
   );
-  
 
   return (
-    <DialogTrigger type="popover">
+    <DialogTrigger onOpenChange={setIsOpen} type="popover">
       <ActionButton isQuiet>
         <MoreVertical size="XXS" />
       </ActionButton>
       <Dialog isDismissable>
         <Heading>{colName}</Heading>
         <Content>
-          {dataSummary && chartForSummary(dataSummary, colName)}
+          {(dataSummary && isOpen) && chartForSummary(dataSummary, colName)}
         </Content>
       </Dialog>
     </DialogTrigger>

--- a/matico_admin/hooks/useColumnStat.ts
+++ b/matico_admin/hooks/useColumnStat.ts
@@ -1,16 +1,14 @@
 import { useSWRAPI, Source, urlForSource, SourceType} from "../utils/api";
 
 export const useColumnStat = (
-  source: Source,
+  source: Source | null | undefined,
   colName: string,
   statDetails: any
 ) => {
-  let url = urlForSource(source,`/columns/${colName}/stats`);
+  let url = source ? urlForSource(source,`/columns/${colName}/stats`): null;
 
-  console.log("Attempting to get stat for ", source, colName, statDetails);
-
-  let params = { stat: JSON.stringify(statDetails), ...source.parameters, q:source.query }
-  if(url && source.type===SourceType.Query){
+  let params = source ? { stat: JSON.stringify(statDetails), ...source.parameters, q:source.query } : null
+  if(url && source?.type===SourceType.Query){
     url = url.split("?")[0]
   }
 


### PR DESCRIPTION
We where getting some performance hits when loading a dataset with many columns. This partly comes from the fact that react spectrum generates all of the content for popups / dialogs even if they are not open. 

Here we add an explicit check to make sure the column stats are not computed until the corresponding pop over is activated