### PR TITLE
Fix data upload preview on osx

### DIFF
--- a/matico_admin/components/DatasetCreation/NewUploadDatasetForm.tsx
+++ b/matico_admin/components/DatasetCreation/NewUploadDatasetForm.tsx
@@ -52,15 +52,31 @@ export const NewUploadDatasetForm: React.FC<NewUploadDatasetFormProps> = () => {
       validator
     });
 
+
+  // todo: refactor this to enumerations of file types and map MIME types to file types
   const previewerForFile = (file: File) => {
-    switch(file.type){
-      case "application/csv":
-      case "text/csv":
-        return <CSVFilePreviewer file={file} />;
-      case "application/geo+json":
-        return <GeoJSONFilePreviewer file={file} />
-        case "application/zip":
-        return <ShpFilePreviewer file={file}/>
+    if (file.type.length){
+      switch(file.type){
+        case "application/csv":
+        case "text/csv":
+          return <CSVFilePreviewer file={file} />;
+        case "application/geo+json":
+          return <GeoJSONFilePreviewer file={file} />
+          case "application/zip":
+          return <ShpFilePreviewer file={file}/>
+      }
+    } else if (file.name.length) {
+      const fileType = file.name.split('.').slice(-1)[0].toLowerCase()
+      switch(fileType){
+        case "csv":
+          return <CSVFilePreviewer file={file} />
+        case "geojson":
+          return <GeoJSONFilePreviewer file={file} />
+        case "zip":
+          return <ShpFilePreviewer file={file}/>
+      } 
+    } else {
+      return null
     }
   };
   


### PR DESCRIPTION
## Overview

This PR fixes the issue with file dropping resulting from MacOS/OSX obscuring MIME type on drop. It uses file extension as a fallback, inferring type. Future work should change this to an accepted file enumeration, rather than hard coded.
