### PR TITLE
Compute docker fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,6 @@ members = [
   "matico_spec_derive",
   "matico_spec",
   "matico_server",
-  "matico_compute/matico_area_analysis",
   "matico_compute/matico_analysis",
   "matico_compute/matico_dot_density_analysis",
   "matico_compute/matico_hdbscam_analysis",

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ RUN cargo build --release
 WORKDIR /app/matico_spec
 RUN wasm-pack build  --release --scope maticoapp
 
+RUN cp -r /app/matico_compute/matico_hdbscam_analysis/pkg /app/matico_server/static/compute/hdbscan
+RUN cp -r /app/matico_compute/matico_dot_density_analysis/pkg  /app/matico_server/static/compute/dot_density
+
 # Install the dependencies for javascript
 #--------------------------------------------------------------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ ADD ./Cargo.toml ./Cargo.toml /app/
 ADD ./matico_spec /app/matico_spec
 ADD ./matico_spec_derive /app/matico_spec_derive
 ADD ./matico_server /app/matico_server
+ADD ./matico_common /app/matico_common
+ADD ./matico_compute /app/matico_compute
 
 WORKDIR /app 
 RUN ls 

--- a/matico_compute/matico_dot_density_analysis/src/lib.rs
+++ b/matico_compute/matico_dot_density_analysis/src/lib.rs
@@ -74,11 +74,11 @@ impl MaticoAnalysisRunner for DotDensityAnalysis {
             console::log_1(&format!("count physical val is {:#?}",counts_raw.data_type().to_physical_type()).into());
 
             let counts= match counts_raw.data_type().to_physical_type(){
-                PhysicalType::Primitive(PrimitiveType::Float32) =>{
-                    let array = counts_raw.as_any().downcast_ref::<PrimitiveArray<f32>>().unwrap();
-                    let array = arrow2::compute::cast::float_to_decimal(array, 100,1);
-                    Ok(array)
-                },
+                // PhysicalType::Primitive(PrimitiveType::Float32) =>{
+                //     let array = counts_raw.as_any().downcast_ref::<PrimitiveArray<f32>>().unwrap();
+                //     let array = arrow2::compute::cast::float_to_decimal(array, 100,1);
+                //     Ok(array)
+                // },
                 PhysicalType::Primitive(PrimitiveType::Int32) =>{
                     let array = counts_raw.as_any().downcast_ref::<PrimitiveArray<i32>>().unwrap();
                     let array = arrow2::compute::cast::integer_to_decimal(&array, 100, 1); 
@@ -100,7 +100,7 @@ impl MaticoAnalysisRunner for DotDensityAnalysis {
             for (index,wkb) in geoms_raw.iter().enumerate(){
                 if wkb.is_some(){
                     let no_points = counts.values()[index];
-                    let no_points = no_points/(dot_per as f32);
+                    let no_points = (no_points as f32)/(dot_per as f32);
                     console::log_1(&format!("generating {} points",no_points).into());
 
                     let mut cursor = Cursor::new(wkb.unwrap());
@@ -145,7 +145,7 @@ impl MaticoAnalysisRunner for DotDensityAnalysis {
     }
 
     fn description()->Option<String>{
-        Some("This generates a number of points randonly placed within each polygon based on some input number".into()) 
+        Some("This generates a number of points randomly placed within each polygon based on some input number".into()) 
     }
 
     fn options() -> BTreeMap<String, ParameterOptions> {


### PR DESCRIPTION
## Overview

Tweaks the dockerfile to be aware of the new compute structure and to to move the compiled compute modules in to the static folder of the server.

### Notes

Eventually we will want to make the compute stored in the DB but this works for testing just now.

## Testing Instructions

- We are going to let the CI test this deploy