### PR TITLE
Using new components for all panes. We are not including controls her…

### DIFF
--- a/matico_components/src/Components/MaticoEditor/EditorComponents/SliderUnitSelector/SliderUnitSelector.tsx
+++ b/matico_components/src/Components/MaticoEditor/EditorComponents/SliderUnitSelector/SliderUnitSelector.tsx
@@ -32,7 +32,7 @@ export const SliderUnitSelector: React.FC<SliderUnitSelectorProps> = ({
           maxValue={sliderMax}
           step={sliderStep}
           onChange={onUpdateValue}
-          flex={"0 1 0px"}
+          flex={"1 1 0px"}
         />
         <NumberField
           value={value}

--- a/matico_components/src/Components/MaticoEditor/Panes/AppEditor.tsx
+++ b/matico_components/src/Components/MaticoEditor/Panes/AppEditor.tsx
@@ -8,11 +8,14 @@ import {
     ActionButton,
     Content,
     Dialog,
-    DialogTrigger
+    DialogTrigger,
+    TextArea
 } from "@adobe/react-spectrum";
 import { RowEntryMultiButton } from "../Utils/RowEntryMultiButton";
 import { Page } from "@maticoapp/matico_types/spec";
 import { useApp } from "Hooks/useApp";
+import { CollapsibleSection } from "../EditorComponents/CollapsibleSection";
+import { ColorPickerDialog } from "../Utils/ColorPickerDialog";
 
 interface AddPageModalProps {
     onAddPage: (pageName: string) => void;
@@ -29,6 +32,11 @@ const AddPageModal: React.FC<AddPageModalProps> = ({
     const attemptToAddPage = (pageName: string, close: () => void) => {
         if (newPageName.length === 0) {
             setErrorText("Please provide a name");
+            <TextField
+                label="MapBox"
+                description="Required to use the application with mapbox gl tiling, geododing or routing"
+                width="100%"
+            />;
         }
         if (validatePageName) {
             if (validatePageName(pageName)) {
@@ -46,7 +54,9 @@ const AddPageModal: React.FC<AddPageModalProps> = ({
 
     return (
         <DialogTrigger type="popover" isDismissable>
-            <ActionButton isQuiet>Add</ActionButton>
+            <ActionButton width="100%" isQuiet>
+                Add
+            </ActionButton>
             {(close: any) => (
                 <Dialog>
                     <Heading>Select pane to add</Heading>
@@ -77,7 +87,7 @@ const AddPageModal: React.FC<AddPageModalProps> = ({
 interface AppEditorProps {}
 
 export const AppEditor: React.FC<AppEditorProps> = () => {
-    const { pages, addPage, removePage, setEditPage } = useApp();
+    const { theme, pages, addPage, removePage, setEditPage, updateTheme, metadata, updateMetadata} = useApp();
     console.log("rendering app editor ", pages);
 
     const addNewPage = (pageName: string) => {
@@ -94,37 +104,58 @@ export const AppEditor: React.FC<AppEditorProps> = () => {
         }
         return true;
     };
+    console.log("theme ", theme)
+
 
     return (
-        <Flex direction="column">
-            <Well>
-                <Heading>
-                    <Flex
-                        direction="row"
-                        justifyContent="space-between"
-                        alignItems="end"
-                    >
-                        <Text>Pages</Text>
-                        <AddPageModal
-                            validatePageName={validatePageName}
-                            onAddPage={addNewPage}
-                        />
-                    </Flex>
-                </Heading>
-                <Flex marginBottom={"size-200"} direction="column">
-                    {pages.map((page: Page) => (
-                        <RowEntryMultiButton
-                            key={page.name}
-                            entryName={page.name}
-                            onRemove={() => removePage(page.id)}
-                            onLower={() => {}}
-                            onRaise={() => {}}
-                            onDuplicate={() => {}}
-                            onSelect={() => setEditPage(page.id)}
-                        />
-                    ))}
-                </Flex>
-            </Well>
+        <Flex width="100%" height="100%" direction="column">
+            <CollapsibleSection title="Theme" isOpen={true}>
+                <Text>Primary Color</Text>
+                <ColorPickerDialog
+                    // @ts-ignore
+                    color={theme?.primaryColor ?? {rgb:[255,0,0]}}
+                    onColorChange={(color) => updateTheme({primaryColor: color})}
+                />
+                <Text>Secondary Color</Text>
+                <ColorPickerDialog
+                    // @ts-ignore
+                    color={theme?.secondaryColor ?? {rgb:[0,255,0]}}
+                    onColorChange={(color) => updateTheme({secondaryColor:color})}
+                />
+            </CollapsibleSection>
+            <CollapsibleSection title="Metadata" isOpen={true}>
+              <TextField label="Name" width="100%" value={metadata.name} onChange={(name)=> updateMetadata({name})}/>
+              <TextArea label="description" width="100%" value={metadata.description} onChange={(description)=>updateMetadata({description})}/>
+            </CollapsibleSection>
+            <CollapsibleSection title="Keys" isOpen={true}>
+                <TextField
+                    label="MapBox"
+                    description="Required to use the application with mapbox gl tiling, geododing or routing"
+                    width="100%"
+                />
+                <TextField
+                    label="MapTiler"
+                    description="Required to use the application with MapTiler tilesets"
+                    width="100%"
+                />
+            </CollapsibleSection>
+            <CollapsibleSection title="Pages" isOpen={true}>
+                {pages.map((page: Page) => (
+                    <RowEntryMultiButton
+                        key={page.name}
+                        entryName={page.name}
+                        onRemove={() => removePage(page.id)}
+                        onLower={() => {}}
+                        onRaise={() => {}}
+                        onDuplicate={() => {}}
+                        onSelect={() => setEditPage(page.id)}
+                    />
+                ))}
+                <AddPageModal
+                    validatePageName={validatePageName}
+                    onAddPage={addNewPage}
+                />
+            </CollapsibleSection>
         </Flex>
     );
 };

--- a/matico_components/src/Components/MaticoEditor/Panes/ContainerPaneEditor.tsx
+++ b/matico_components/src/Components/MaticoEditor/Panes/ContainerPaneEditor.tsx
@@ -1,17 +1,14 @@
 import React from "react";
 import _ from "lodash";
-import { Flex, Text } from "@adobe/react-spectrum";
+import { Flex, Text, TextField } from "@adobe/react-spectrum";
 
-import { RowEntryMultiButton } from "../Utils/RowEntryMultiButton";
 import { PaneEditor } from "./PaneEditor";
 import { LayoutEditor } from "./LayoutEditor";
 import { useContainer } from "Hooks/useContainer";
-import { Pane, PaneRef } from "@maticoapp/matico_types/spec";
-import { IconForPaneType } from "../Utils/PaneDetails";
-import { NewPaneDialog } from "../EditorComponents/NewPaneDialog/NewPaneDialog";
+import { PaneRef } from "@maticoapp/matico_types/spec";
 import { CollapsibleSection } from "../EditorComponents/CollapsibleSection";
 import { GatedAction } from "../EditorComponents/GatedAction";
-import {PaneCollectionEditor} from "../EditorComponents/PaneCollectionEditor/PaneCollectionEditor";
+import { PaneCollectionEditor } from "../EditorComponents/PaneCollectionEditor/PaneCollectionEditor";
 
 export interface SectionEditorProps {
     paneRef: PaneRef;
@@ -20,17 +17,20 @@ export interface SectionEditorProps {
 export const ContainerPaneEditor: React.FC<SectionEditorProps> = ({
     paneRef
 }) => {
-    const {
-        container,
-        removePane,
-        updatePane,
-        updatePanePosition,
-        parent,
-    } = useContainer(paneRef);
+    const { container, removePane, updatePane, updatePanePosition, parent } =
+        useContainer(paneRef);
 
     return (
         <Flex width="100%" height="100%" direction="column">
-            <CollapsibleSection title="Size" isOpen={true}>
+            <CollapsibleSection title="Basic" isOpen={true}>
+                <TextField
+                    width="100%"
+                    label="name"
+                    value={container.name}
+                    onChange={(name) => updatePane({ name })}
+                />
+            </CollapsibleSection>
+            <CollapsibleSection title="Layout" isOpen={true}>
                 <PaneEditor
                     position={paneRef.position}
                     name={container.name}
@@ -44,11 +44,11 @@ export const ContainerPaneEditor: React.FC<SectionEditorProps> = ({
                 <LayoutEditor
                     name={container.name}
                     layout={container.layout}
-                    updateLayout={(update)  => updatePane({layout: update})}
+                    updateLayout={(update) => updatePane({ layout: update })}
                 />
             </CollapsibleSection>
             <CollapsibleSection title="Panes" isOpen={true}>
-              <PaneCollectionEditor containerId={paneRef.paneId} />
+                <PaneCollectionEditor containerId={paneRef.paneId} />
             </CollapsibleSection>
             <CollapsibleSection title="Danger Zone">
                 <GatedAction

--- a/matico_components/src/Components/MaticoEditor/Panes/HistogramPaneEditor.tsx
+++ b/matico_components/src/Components/MaticoEditor/Panes/HistogramPaneEditor.tsx
@@ -1,16 +1,16 @@
 import React from "react";
 import _ from "lodash";
 import { useMaticoSelector } from "Hooks/redux";
-import { Text, Flex, View, Divider } from "@adobe/react-spectrum";
+import { Text, Flex, View, Divider, TextField } from "@adobe/react-spectrum";
 import { DatasetSelector } from "../Utils/DatasetSelector";
 import { DatasetColumnSelector } from "../Utils/DatasetColumnSelector";
 import { PaneEditor } from "./PaneEditor";
-import { NumericVariableEditor } from "../Utils/NumericVariableEditor";
-import { ColorVariableEditor } from "../Utils/ColorVariableEditor";
+import { ColorVariableEditor } from "../EditorComponents/ColorVariableEditor";
 import { LabelEditor } from "../Utils/LabelEditor";
 import { usePane } from "Hooks/usePane";
 import { HistogramPane, Labels, PaneRef } from "@maticoapp/matico_types/spec";
 import { CollapsibleSection } from "../EditorComponents/CollapsibleSection";
+import { SliderUnitSelector } from "../EditorComponents/SliderUnitSelector";
 
 export interface PaneEditorProps {
     paneRef: PaneRef;
@@ -45,6 +45,8 @@ export const HistogramPaneEditor: React.FC<PaneEditorProps> = ({ paneRef }) => {
         (state) => state.datasets.datasets[histogramPane.dataset.name]
     );
 
+    const { columns } = dataset;
+
     if (!histogramPane) {
         return (
             <View>
@@ -55,7 +57,15 @@ export const HistogramPaneEditor: React.FC<PaneEditorProps> = ({ paneRef }) => {
 
     return (
         <Flex direction="column">
-            <CollapsibleSection title="Sizing" isOpen={true}>
+            <CollapsibleSection title="Basic" isOpen={true}>
+                <TextField
+                    width="100%"
+                    label="name"
+                    value={histogramPane.name}
+                    onChange={(name) => updatePane({ name })}
+                />
+            </CollapsibleSection>
+            <CollapsibleSection title="Layout" isOpen={true}>
                 <PaneEditor
                     position={paneRef.position}
                     name={histogramPane.name}
@@ -78,29 +88,32 @@ export const HistogramPaneEditor: React.FC<PaneEditorProps> = ({ paneRef }) => {
                 />
             </CollapsibleSection>
             {dataset && (
-                <CollapsibleSection title="Chart Settings" isOpen={true}>
-                    <Text>Style</Text>
-                    <NumericVariableEditor
-                        label="Number of bins"
-                        minVal={2}
-                        maxVal={100}
-                        style={histogramPane.maxbins}
-                        datasetName={histogramPane.dataset.name}
-                        onUpdateStyle={(maxbins) => updatePane({ maxbins })}
-                    />
+                <>
+                    <CollapsibleSection title="Settings" isOpen={true}>
+                        <Text>Max bins</Text>
+                        <SliderUnitSelector
+                            label="Number of bins"
+                            sliderMin={2}
+                            sliderMax={100}
+                            value={histogramPane.maxbins}
+                            onUpdateValue={(maxbins) => updatePane({ maxbins })}
+                            sliderStep={1}
+                        />
 
-                    <ColorVariableEditor
-                        label="Color"
-                        style={histogramPane.color}
-                        datasetName={histogramPane.dataset.name}
-                        onUpdateStyle={(color) => updatePane({ color })}
-                    />
-                    <Divider />
+                        <ColorVariableEditor
+                            label="Color"
+                            style={histogramPane.color}
+                            datasetName={histogramPane.dataset.name}
+                            columns={columns}
+                            onUpdateStyle={(color) => updatePane({ color })}
+                        />
+                        <Divider />
+                    </CollapsibleSection>
                     <LabelEditor
                         labels={histogramPane.labels}
                         onUpdateLabels={updateLabels}
                     />
-                </CollapsibleSection>
+                </>
             )}
         </Flex>
     );

--- a/matico_components/src/Components/MaticoEditor/Panes/LayerEditor.tsx
+++ b/matico_components/src/Components/MaticoEditor/Panes/LayerEditor.tsx
@@ -150,7 +150,7 @@ export const LayerEditor: React.FC<LayerEditorProps> = ({
                         columns={columns}
                         onUpdateValue={(style) => updateStyle("size", style)}
                         sliderMin={0}
-                        sliderMax={2000}
+                        sliderMax={20}
                     />
                     <TwoUpCollapsableGrid
                         gridProps={{

--- a/matico_components/src/Components/MaticoEditor/Panes/LayoutEditor.tsx
+++ b/matico_components/src/Components/MaticoEditor/Panes/LayoutEditor.tsx
@@ -4,7 +4,8 @@ import {
     Picker,
     Item,
     Radio,
-    RadioGroup
+    RadioGroup,
+    Flex
 } from "@adobe/react-spectrum";
 import { availableLayouts } from "Utils/layoutEngine";
 import { Layout, LinearLayout, FreeLayout, LinearLayoutDirection, Alignment,Justification} from "@maticoapp/matico_types/spec";
@@ -19,14 +20,16 @@ export const LinearLayoutEditor: React.FC<LinearLayoutEditorProps> = ({
     onChange
 }) => {
     return (
-        <>
+        <Flex direction='column' rowGap='size-300' marginTop="size-300">
             <RadioGroup
                 label="Flow direction"
                 value={layout.direction}
                 onChange={(val) => onChange({ direction: val as LinearLayoutDirection })}
             >
+                <Flex direction='row'>
                 <Radio value="row">Horizontal</Radio>
                 <Radio value="column">Vertical</Radio>
+              </Flex>
             </RadioGroup>
 
             <RadioGroup
@@ -34,11 +37,13 @@ export const LinearLayoutEditor: React.FC<LinearLayoutEditorProps> = ({
                 value={layout.align}
                 onChange={(val) => onChange({ align: val  as Alignment})}
             >
+                <Flex direction="row" wrap={"wrap"}>
                 <Radio value="flex-start">Start</Radio>
                 <Radio value="center">Center</Radio>
                 <Radio value="flex-end">End</Radio>
                 <Radio value="stretch">Stretch</Radio>
                 <Radio value="baseline">Baseline</Radio>
+              </Flex>
             </RadioGroup>
 
             <RadioGroup
@@ -46,14 +51,16 @@ export const LinearLayoutEditor: React.FC<LinearLayoutEditorProps> = ({
                 value={layout.justify}
                 onChange={(val) => onChange({ justify: val as Justification})}
             >
+                <Flex direction='row' wrap={"wrap"}>
                 <Radio value="flex-start">Start</Radio>
                 <Radio value="center">Center</Radio>
                 <Radio value="flex-end">End</Radio>
                 <Radio value="space-between">Space Between</Radio>
                 <Radio value="space-around">Space Around</Radio>
                 <Radio value="space-evenly">Space Evenly</Radio>
+              </Flex>
             </RadioGroup>
-        </>
+        </Flex>
     );
 };
 
@@ -91,6 +98,7 @@ export const LayoutEditor: React.FC<LayoutEditorProps> = ({
     return (
         <View>
             <Picker
+                width="100%"
                 selectedKey={layout.type}
                 label="Layout"
                 onSelectionChange={(layout) =>

--- a/matico_components/src/Components/MaticoEditor/Panes/MapPaneEditor.tsx
+++ b/matico_components/src/Components/MaticoEditor/Panes/MapPaneEditor.tsx
@@ -232,10 +232,15 @@ export const MapPaneEditor: React.FC<PaneEditorProps> = ({ paneRef }) => {
 
     return (
         <Flex direction="column">
-            <CollapsibleSection title="Details">
-
+            <CollapsibleSection title="Basic" isOpen={true}>
+                <TextField
+                    width="100%"
+                    label="name"
+                    value={mapPane.name}
+                    onChange={(name) => updatePane({ name })}
+                />
             </CollapsibleSection>
-            <CollapsibleSection title="Sizing" isOpen={true}>
+            <CollapsibleSection title="Layout" isOpen={true}>
                 <PaneEditor
                     position={paneRef.position}
                     name={mapPane.name}

--- a/matico_components/src/Components/MaticoEditor/Panes/PieChartPaneEditor.tsx
+++ b/matico_components/src/Components/MaticoEditor/Panes/PieChartPaneEditor.tsx
@@ -3,7 +3,7 @@ import _ from "lodash";
 import { DatasetSelector } from "../Utils/DatasetSelector";
 import { DatasetColumnSelector } from "../Utils/DatasetColumnSelector";
 import { PaneEditor } from "./PaneEditor";
-import { Text, View } from "@adobe/react-spectrum";
+import { Text, TextField, View } from "@adobe/react-spectrum";
 import { usePane } from "Hooks/usePane";
 import { PaneRef, PieChartPane } from "@maticoapp/matico_types/spec";
 import { CollapsibleSection } from "../EditorComponents/CollapsibleSection";
@@ -40,7 +40,15 @@ export const PieChartPaneEditor: React.FC<PaneEditorProps> = ({ paneRef }) => {
 
     return (
         <View>
-            <CollapsibleSection title="Sizing" isOpen={true}>
+            <CollapsibleSection title="Basic" isOpen={true}>
+                <TextField
+                    width="100%"
+                    label="name"
+                    value={pieChartPane.name}
+                    onChange={(name) => updatePane({ name })}
+                />
+            </CollapsibleSection>
+            <CollapsibleSection title="Layout" isOpen={true}>
                 <PaneEditor
                     position={paneRef.position}
                     name={pieChartPane.name}

--- a/matico_components/src/Components/MaticoEditor/Panes/ScatterPlotPaneEditor.tsx
+++ b/matico_components/src/Components/MaticoEditor/Panes/ScatterPlotPaneEditor.tsx
@@ -1,18 +1,19 @@
 import React from "react";
 import _ from "lodash";
 import { useMaticoSelector } from "Hooks/redux";
-import { Text, View } from "@adobe/react-spectrum";
+import { Text, TextField, View } from "@adobe/react-spectrum";
 import { DatasetSelector } from "../Utils/DatasetSelector";
 import { DatasetColumnSelector } from "../Utils/DatasetColumnSelector";
 import { PaneEditor } from "./PaneEditor";
 import { NumericVariableEditor } from "../Utils/NumericVariableEditor";
-import { ColorVariableEditor } from "../Utils/ColorVariableEditor";
+import { ColorVariableEditor } from "../EditorComponents/ColorVariableEditor";
 import { DatasetSummary } from "Datasets/Dataset";
 import { LabelEditor } from "../Utils/LabelEditor";
 import { TwoUpCollapsableGrid } from "../Utils/TwoUpCollapsableGrid";
 import { usePane } from "Hooks/usePane";
 import { Labels, PaneRef, ScatterplotPane } from "@maticoapp/matico_types/spec";
 import { CollapsibleSection } from "../EditorComponents/CollapsibleSection";
+import { SliderVariableEditor } from "../EditorComponents/SliderVariableEditor";
 
 export interface PaneEditorProps {
     paneRef: PaneRef;
@@ -52,7 +53,15 @@ export const ScatterplotPaneEditor: React.FC<PaneEditorProps> = ({
 
     return (
         <View>
-            <CollapsibleSection title="Sizing" isOpen={true}>
+            <CollapsibleSection title="Basic" isOpen={true}>
+                <TextField
+                    width="100%"
+                    label="name"
+                    value={scatterplotPane.name}
+                    onChange={(name) => updatePane({ name })}
+                />
+            </CollapsibleSection>
+            <CollapsibleSection title="Layout" isOpen={true}>
                 <PaneEditor
                     position={paneRef.position}
                     name={scatterplotPane.name}
@@ -68,7 +77,7 @@ export const ScatterplotPaneEditor: React.FC<PaneEditorProps> = ({
                     onDatasetSelected={updateDataset}
                 />
                 {dataset ? (
-                    <TwoUpCollapsableGrid>
+                    <>
                         <DatasetColumnSelector
                             label="X Column"
                             datasetName={scatterplotPane?.dataset.name}
@@ -85,19 +94,20 @@ export const ScatterplotPaneEditor: React.FC<PaneEditorProps> = ({
                                 updatePane({ yColumn: yColumn.name })
                             }
                         />
-                    </TwoUpCollapsableGrid>
+                    </>
                 ) : (
                     <Text>Select a dataset to see column options.</Text>
                 )}
             </CollapsibleSection>
             <CollapsibleSection title="Chart Styles" isOpen={true}>
-                <NumericVariableEditor
-                    label="Dot Size"
-                    datasetName={scatterplotPane?.dataset.name}
-                    style={scatterplotPane.dotSize}
-                    onUpdateStyle={(dotSize) => updatePane({ dotSize })}
-                    minVal={0}
-                    maxVal={100}
+                <SliderVariableEditor
+                    label="Point Radius"
+                    style={scatterplotPane?.dotSize}
+                    datasetName={dataset.name}
+                    columns={dataset.columns}
+                    onUpdateValue={(dotSize) => updatePane({ dotSize })}
+                    sliderMin={0}
+                    sliderMax={2000}
                 />
 
                 <ColorVariableEditor
@@ -105,10 +115,7 @@ export const ScatterplotPaneEditor: React.FC<PaneEditorProps> = ({
                     datasetName={scatterplotPane?.dataset.name}
                     style={scatterplotPane?.dotColor}
                     onUpdateStyle={(dotColor) => updatePane({ dotColor })}
-                />
-                <LabelEditor
-                    labels={scatterplotPane?.labels}
-                    onUpdateLabels={updateLabels}
+                    columns={dataset.columns}
                 />
             </CollapsibleSection>
             <CollapsibleSection title="Interaction" isOpen={true}>
@@ -135,6 +142,10 @@ export const ScatterplotPaneEditor: React.FC<PaneEditorProps> = ({
                     <Text>Select a dataset to see interaction options.</Text>
                 )}
             </CollapsibleSection>
+            <LabelEditor
+                labels={scatterplotPane?.labels}
+                onUpdateLabels={updateLabels}
+            />
         </View>
     );
 };

--- a/matico_components/src/Components/MaticoEditor/Utils/LabelEditor.tsx
+++ b/matico_components/src/Components/MaticoEditor/Utils/LabelEditor.tsx
@@ -1,6 +1,7 @@
 import { Flex, Heading, TextField, Well } from "@adobe/react-spectrum";
 import { Labels } from "@maticoapp/matico_types/spec";
 import React from "react";
+import {CollapsibleSection} from "../EditorComponents/CollapsibleSection";
 
 interface LabelEditorProps {
     labels: Labels;
@@ -12,9 +13,8 @@ export const LabelEditor: React.FC<LabelEditorProps> = ({
     onUpdateLabels
 }) => {
     return (
-        <Well>
-            <Heading>Labels</Heading>
-            <Flex direction="column">
+      <CollapsibleSection title="Labels">
+            <Flex direction="column" width="100%">
                 <TextField
                     width="100%"
                     label="title"
@@ -46,6 +46,6 @@ export const LabelEditor: React.FC<LabelEditorProps> = ({
                     onChange={(yLabel) => onUpdateLabels({ yLabel })}
                 />
             </Flex>
-        </Well>
+        </CollapsibleSection>
     );
 };

--- a/matico_components/src/Hooks/useApp.ts
+++ b/matico_components/src/Hooks/useApp.ts
@@ -1,8 +1,5 @@
 import {
     Page,
-    Pane,
-    ContainerPane,
-    PaneRef
 } from "@maticoapp/matico_types/spec";
 import { useMaticoDispatch, useMaticoSelector } from "./redux";
 import {
@@ -10,16 +7,18 @@ import {
     removePage,
     addPage,
     setCurrentEditElement,
-    addPaneRefToContainer,
-    removePaneFromContainer,
-    reparentPaneRef
+    reparentPaneRef,
+    updateTheme
 } from "../Stores/MaticoSpecSlice";
 import { v4 as uuidv4 } from "uuid";
+import {Theme} from "@maticoapp/matico_types/spec";
+import {Metadata} from "@maticoapp/matico_types/spec";
 
 export const useApp = () => {
     const { metadata, pages, panes, theme } = useMaticoSelector(
         (selector) => selector.spec.spec
     );
+
     const dispatch = useMaticoDispatch();
 
     const addPageLocal = (page: Partial<Page>) => {
@@ -47,6 +46,9 @@ export const useApp = () => {
         );
     };
 
+    const _updateMetadata = (update:Partial<Metadata>)=>{
+      dispatch(updateMetadata({update}))
+    }
     const updatePage = (pageId: string, update: Partial<Page>) => {
         dispatch(updatePageDetails({ pageId, update }));
     };
@@ -54,6 +56,10 @@ export const useApp = () => {
     const removePageLocal = (pageId: string) => {
         dispatch(removePage({ pageId, removeOrphanPanes: false }));
     };
+
+    const _updateTheme= (update: Partial<Theme>)=>{
+        dispatch(updateTheme({update}))
+    }
 
     const reparentPane = (
         paneRefId: string,
@@ -76,6 +82,7 @@ export const useApp = () => {
         addPage: addPageLocal,
         updatePage,
         setEditPage,
-        reparentPane
+        reparentPane,
+        updateTheme: _updateTheme
     };
 };

--- a/matico_components/src/Stores/MaticoSpecSlice.tsx
+++ b/matico_components/src/Stores/MaticoSpecSlice.tsx
@@ -12,6 +12,7 @@ import {
 import _ from "lodash";
 import { findPagesForPane, findPaneOrPage } from "Utils/specUtils/specUtils";
 import { stringValue } from "vega";
+import {Theme} from "@maticoapp/matico_types/spec";
 
 
 export type EditElement = {
@@ -271,6 +272,16 @@ export const stateSlice = createSlice({
             );
             layers.slice(newIndex, 0, layer);
         },
+        updateTheme:( state, action:PayloadAction<{update:Partial<Theme>}>)=>{
+          let theme = state.spec.theme;
+          let update = action.payload.update;
+          Object.assign(theme,update)
+        },
+        updateMetadata:( state, action:PayloadAction<{update:Partial<Metadata>}>)=>{
+          let theme = state.spec.metadata;
+          let update = action.payload.update;
+          Object.assign(metadata,update)
+        },
         updateLayer: (
             state,
             action: PayloadAction<{
@@ -341,7 +352,9 @@ export const {
     removePaneRef,
     reparentPaneRef,
     removePaneRefFromContainer,
-    updatePageDetails
+    updatePageDetails,
+    updateTheme,
+    updateMetadata
 } = stateSlice.actions;
 
 export const selectSpec = (state: SpecState) => state.spec;


### PR DESCRIPTION
…e as we plan to split these out in to individual panes

## Overview

Standardizing the editor pane components to have the same structure and use the new components 


### Demo

Container : 

![image](https://user-images.githubusercontent.com/209838/181638962-462e69e6-2b39-4447-b286-ed13b1519ce3.png)

Map:

![image](https://user-images.githubusercontent.com/209838/181639056-32751b26-bec0-4f7e-8940-5fceb4a4da98.png)

Layer:

![image](https://user-images.githubusercontent.com/209838/181639128-f0c85ccc-d84a-4676-9664-8d78ecc96bb8.png)

Scatterplot:

![image](https://user-images.githubusercontent.com/209838/181639208-fd1b047d-064e-43f1-a61e-a715617b8b02.png)

PieChart:

![image](https://user-images.githubusercontent.com/209838/181639291-f99b52e8-3494-4f13-a857-91b849a5d79d.png)

histogram:

![image](https://user-images.githubusercontent.com/209838/181639776-8d95fa2d-9bb2-49e9-90b4-e94e04cbf27b.png)


### Notes

Have omitted the controls pane just now as I want to see about making them their own pane type.
Pie Charts are having some issues. Working on these next 

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output