### PR TITLE
Adding quick presets for containers

### DIFF
--- a/matico_components/src/Components/MaticoEditor/EditorComponents/NewPaneDialog/NewPaneDialog.tsx
+++ b/matico_components/src/Components/MaticoEditor/EditorComponents/NewPaneDialog/NewPaneDialog.tsx
@@ -16,8 +16,16 @@ import { v4 as uuidv4 } from "uuid";
 import {
     PaneDefaults,
     IconForPaneType,
-    AvaliablePanes
+    AvaliablePanes,
+    ContainerPresetTypes,
+    containerPreset
 } from "Components/MaticoEditor/Utils/PaneDetails";
+
+import RailRightIcon from "@spectrum-icons/workflow/RailRight";
+import ViewSingle from "@spectrum-icons/workflow/ViewSingle";
+import ViewRow from "@spectrum-icons/workflow/ViewRow";
+import ViewColumn from "@spectrum-icons/workflow/ViewColumn";
+import {useApp} from "Hooks/useApp";
 
 interface NewPaneDialogProps {
     validatePaneName?: (name: string) => boolean;
@@ -28,12 +36,29 @@ export const NewPaneDialog: React.FC<NewPaneDialogProps> = ({
     validatePaneName,
     onAddPane
 }) => {
+    const {addPane} = useApp();
     const [newPaneName, setNewPaneName] = useState("New Pane");
     const [errorText, setErrorText] = useState<string | null>(null);
+    const [showContainerPresets, setShowContainerPresets] =
+        useState<boolean>(false);
+
+
+    const addContainerPaneType =( type: ContainerPresetTypes, close:()=>void)=>{
+      const {container,additionalPanes} = containerPreset(newPaneName, type) 
+      additionalPanes.forEach((p)=>{
+          addPane(p);
+      })
+      onAddPane(container)
+      close()
+    }
 
     const attemptToAddPane = (paneType: string, close: () => void) => {
         if (newPaneName.length === 0) {
             setErrorText("Please provide a name");
+        }
+        if (paneType === "container") {
+            setShowContainerPresets(true);
+            return;
         }
         if (validatePaneName) {
             if (validatePaneName(newPaneName)) {
@@ -61,45 +86,95 @@ export const NewPaneDialog: React.FC<NewPaneDialogProps> = ({
                 <Dialog>
                     <Heading>Select pane to add</Heading>
                     <Content>
-                        {AvaliablePanes.map((section) => (
-                            <Flex direction="column" key={section.sectionTitle} gap="size-150">
-                                <TextField
-                                    label="New pane name"
-                                    value={newPaneName}
-                                    onChange={setNewPaneName}
-                                    errorMessage={errorText}
-                                    width="100%"
-                                ></TextField>
-                                <DefaultGrid
-                                    columns={repeat(2, "1fr")}
-                                    columnGap={"size-150"}
-                                    rowGap={"size-150"}
-                                    autoRows="fit-content"
-                                    marginBottom="size-200"
-                                >
-                                    {section.panes.map(
-                                        (pane: {
-                                            name: string;
-                                            label: string;
-                                        }) => (
-                                            <ActionButton
-                                                key={pane.name}
-                                                onPress={() => {
-                                                    attemptToAddPane(
-                                                        pane.name,
-                                                        close
-                                                    );
-                                                }}
-                                            >
-                                                {IconForPaneType(pane.name)}
-                                                <Text>{pane.label}</Text>
-                                            </ActionButton>
-                                        )
-                                    )}
-                                </DefaultGrid>
-                            </Flex>
-                        ))}
+                        <Flex
+                            direction="column"
+                            gap="size-150"
+                        >
+                            <TextField
+                                label="New pane name"
+                                value={newPaneName}
+                                onChange={setNewPaneName}
+                                errorMessage={errorText}
+                                width="100%"
+                            ></TextField>
+                            {showContainerPresets ? (
+                                <>
+                                    <DefaultGrid
+                                        columns={repeat(2, "1fr")}
+                                        columnGap={"size-150"}
+                                        rowGap={"size-150"}
+                                        autoRows="fit-content"
+                                        marginBottom="size-200"
+                                    >
+                                      <ActionButton key={"sidebarHorizontal"}
+                                          onPress={()=>addContainerPaneType("mainSideBar", close)}
+                                        >
+                                            <RailRightIcon />
+                                            <Text>Main Sidebar</Text>
+                                        </ActionButton>
+                                        <ActionButton key={"free"}
+                                          onPress={()=>addContainerPaneType("full", close)}
+                                        >
+                                            <ViewSingle />
+                                            <Text>Free Layout</Text>
+                                        </ActionButton>
+                                        <ActionButton key={"linearHorizontal"}
+                                                    
+                                          onPress={()=>addContainerPaneType("row",close)}
+                                        >
+                                            <ViewRow />
+                                            <Text>Row</Text>
+                                        </ActionButton>
+                                        <ActionButton key={"linearVertical"}
+                                          onPress={()=>addContainerPaneType("column",close)}
+
+                                        >
+                                            <ViewColumn />
+                                            <Text>Column</Text>
+                                        </ActionButton>
+                                    </DefaultGrid>
+                                    <ActionButton
+                                        onPress={() =>
+                                            setShowContainerPresets(false)
+                                        }
+                                    >
+                                        Back to panes
+                                    </ActionButton>
+                                </>
+                            ) : (
+                                AvaliablePanes.map((section) => (
+                                    <DefaultGrid
+                                        columns={repeat(2, "1fr")}
+                                        columnGap={"size-150"}
+                                        rowGap={"size-150"}
+                                        autoRows="fit-content"
+                                        marginBottom="size-200"
+                                    >
+                                        {section.panes.map(
+                                            (pane: {
+                                                name: string;
+                                                label: string;
+                                            }) => (
+                                                <ActionButton
+                                                    key={pane.name}
+                                                    onPress={() => {
+                                                        attemptToAddPane(
+                                                            pane.name,
+                                                            close
+                                                        );
+                                                    }}
+                                                >
+                                                    {IconForPaneType(pane.name)}
+                                                    <Text>{pane.label}</Text>
+                                                </ActionButton>
+                                            )
+                                        )}
+                                    </DefaultGrid>
+                                ))
+                            )}
+                        </Flex>
                     </Content>
+                    )
                 </Dialog>
             )}
         </DialogTrigger>

--- a/matico_components/src/Components/MaticoEditor/Panes/LayoutEditor.tsx
+++ b/matico_components/src/Components/MaticoEditor/Panes/LayoutEditor.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import {
-    View,
+import { View,
     Picker,
     Item,
     Radio,
@@ -95,7 +94,7 @@ export const LayoutEditor: React.FC<LayoutEditorProps> = ({
 
     const Editor = LayoutEditorMap[layout.type as keyof typeof LayoutEditorMap];
     return (
-        <View>
+        <View width="100%">
             <Picker
                 width="100%"
                 selectedKey={layout.type}

--- a/matico_components/src/Components/MaticoEditor/Utils/PaneDetails.tsx
+++ b/matico_components/src/Components/MaticoEditor/Utils/PaneDetails.tsx
@@ -6,7 +6,8 @@ import MapIcon from "@spectrum-icons/workflow/MapView";
 import ScatterIcon from "@spectrum-icons/workflow/GraphScatter";
 import PropertiesIcon from "@spectrum-icons/workflow/Properties";
 import Border from "@spectrum-icons/workflow/Border";
-import { Layer, Pane, PanePosition } from "@maticoapp/matico_types/spec";
+import { ContainerPane, Layer, Pane, PanePosition } from "@maticoapp/matico_types/spec";
+import {v4 as uuid} from 'uuid'
 
 export const IconForPaneType = (PaneType: string) => {
     switch (PaneType) {
@@ -23,8 +24,7 @@ export const IconForPaneType = (PaneType: string) => {
         case "controls":
             return <PropertiesIcon />;
         case "container":
-            return <Border />;
-    }
+            return <Border />; }
 };
 
 type AvaliablePanesSection = {
@@ -77,6 +77,29 @@ export const DefaultPosition: PanePosition = {
     padUnitsTop: "pixels",
     padUnitsBottom: "pixels"
 };
+
+
+export const FullPosition : PanePosition={
+
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+    float: false,
+    layer: 1,
+    xUnits: "percent",
+    yUnits: "percent",
+    widthUnits: "percent",
+    heightUnits: "percent",
+    padLeft: 0,
+    padRight: 0,
+    padTop: 0,
+    padBottom: 0,
+    padUnitsLeft: "pixels",
+    padUnitsRight: "pixels",
+    padUnitsTop: "pixels",
+    padUnitsBottom: "pixels"
+}
 
 const DefaultView = {
     lat: 40.794983,
@@ -144,8 +167,84 @@ export const PaneDefaults: Record<string, Partial<Pane>> = {
     },
     container: {
         name: "Container",
-        title: "Container",
         layout: { type: "free"},
         panes: []
     }
 };
+
+export type ContainerPresetTypes = "full" | "mainSideBar" | "row" | "column";
+
+export const containerPreset = (name: string, presetType: ContainerPresetTypes) => {
+
+  switch(presetType){
+    case "full":
+
+      let full ={
+        id:uuid(),
+        name:name,
+        layout: {type:"free", allowOverflow:false},
+        type: 'container',
+        panes:[]
+      }
+      return {container: full, additionalPanes:[]}
+    
+    case "row":
+      let rowContainer ={
+        id:uuid(),
+        name:name,
+        type: 'container',
+        layout: {type:"linear", direction:"row", justify:'flex-start', align:"center", allowOverflow:false},
+        panes:[]
+      }
+      return {container: rowContainer, additionalPanes:[]}
+
+    case "column":
+      let columnContainer ={
+        id:uuid(),
+        name:name,
+        type: 'container',
+        layout: {type:"linear", direction:"column", justify:'flex-start', align:"center", allowOverflow:false},
+        panes:[]
+      }
+      return {container: columnContainer, additionalPanes:[]}
+
+
+    case "mainSideBar":
+
+      let MainContentPane = {
+        id: uuid(),
+        type: 'container',
+        name:`${name}: Main`,
+        layout:{type:"free", allowOverflow:false },
+        panes:[]
+      }
+
+      let SideBar= {
+        id:uuid(),
+        type:'container',
+        name: `${name}: SideBar`,
+        layout:{type:"linear", direction:"row",  allowOverflow:true, 
+            justify: "flex-start",
+            align: "center"
+        },
+        panes:[]
+      }
+  
+      let mainSideBarHorizontal ={
+        id: uuid(),
+        type:"container",
+        name:name,
+        layout:{type: "linear", direction:"row", justify:'flex-start', align:"center", allowOverflow:false},
+        panes:[
+          {id:uuid(), type:'container', paneId:MainContentPane.id, position: {...FullPosition, width:70}},
+          {id:uuid(), type:'container', paneId:SideBar.id, position: {...FullPosition, width:30}},
+        ]
+      }
+
+      return {container: mainSideBarHorizontal, additionalPanes:[MainContentPane,SideBar]}
+
+      default:
+        throw(`Unsupported container layout ${ presetType}`)
+
+    }
+}

--- a/matico_components/src/Hooks/useApp.ts
+++ b/matico_components/src/Hooks/useApp.ts
@@ -1,5 +1,5 @@
 import {
-    Page,
+    Page, Pane,
 } from "@maticoapp/matico_types/spec";
 import { useMaticoDispatch, useMaticoSelector } from "./redux";
 import {
@@ -8,7 +8,8 @@ import {
     addPage,
     setCurrentEditElement,
     reparentPaneRef,
-    updateTheme
+    updateTheme,
+    addPane
 } from "../Stores/MaticoSpecSlice";
 import { v4 as uuidv4 } from "uuid";
 import {Theme} from "@maticoapp/matico_types/spec";
@@ -27,9 +28,9 @@ export const useApp = () => {
                 page: {
                     name: pages.length === 0 ? "Home" : `Page ${pages.length}`,
                     id: uuidv4(),
-                    layout: { type: "free" },
+                    layout: { type: "free", allowOverflow:false },
                     panes: [],
-                    icon: pages.length === 0 ? "faHome" : "faPage",
+                    icon: pages.length === 0 ? "fa faHome" : "fa faPage",
                     path: pages.length === 0 ? "/" : `/page_${pages.length}`,
                     ...page
                 }
@@ -61,6 +62,10 @@ export const useApp = () => {
         dispatch(updateTheme({update}))
     }
 
+    const _addPane =(pane: Pane)=>{
+        dispatch(addPane({pane}))
+    }
+
     const reparentPane = (
         paneRefId: string,
         targetId: string
@@ -83,6 +88,7 @@ export const useApp = () => {
         updatePage,
         setEditPage,
         reparentPane,
+        addPane:_addPane,
         updateTheme: _updateTheme
     };
 };


### PR DESCRIPTION
## Overview

Adds container presets to container creation. Currently 

"full" : Free layout 
"row": Linear layout in rows 
"column" : Linear layout in columns.
"mainSidebar": Two Linear layouts that achieve a main free panel and a scrolling row based side panel

### Demo

![image](https://user-images.githubusercontent.com/209838/182943010-a352d328-d779-4797-8cde-0378eed8c63b.png)

### Notes

Should be easy to add more of these as we go to help build out apps easier