### PR TITLE
Overflow options for Linear Layouts

### DIFF
--- a/matico_components/src/Components/Layouts/MaticoLinearLayout/MaticoLinearLayout.tsx
+++ b/matico_components/src/Components/Layouts/MaticoLinearLayout/MaticoLinearLayout.tsx
@@ -11,30 +11,51 @@ import { View, Flex } from "@adobe/react-spectrum";
 import { ControlActionBar } from "Components/MaticoEditor/Utils/ControlActionBar";
 import { PaneSelector } from "Utils/paneEngine";
 
-/**
- * If the unit is percent, return percent, otherwise return pixels.
- * @param {string} unit - string - This is the unit that the user has selected in the dropdown.
- */
-const handleHorizontalUnits = (unit: string) =>
-    unit === "percent" ? "%" : "px";
+type UnitTree = {
+    [position: string]: {
+        [direction: string]: {
+            [unit: string]: string;
+        };
+    };
+};
 
-/**
- * If the unit is Percent, return Viewport height, otherwise return px
- * @param {string} unit - string - This is the unit that the user has selected in the dropdown.
- */
-const handleVerticalUnits = (unit: string) =>
-    unit === "percent" ? "%" : "px";
+const unitTree: UnitTree = {
+    vertical: {
+        row: {
+            percent: "%"
+        },
+        column: {
+            percent: "vh"
+        }
+    },
+    horizontal: {
+        row: {
+            percent: "vw"
+        },
+        column: {
+            percent: "%"
+        }
+    }
+};
 
 /**
  * If the position is horizontal, then return the result of calling handleHorizontalUnits with the
  * unit, otherwise return the result of calling handleVerticalUnits with the unit.
  * @param {string} unit - string - The unit to be converted.
  * @param {'vertical' | 'horizontal'} position - 'vertical' | 'horizontal'
+ * @param {'row | 'column'} direction - 'row' | 'column'
  */
-const handleUnits = (unit: string, position: "vertical" | "horizontal") =>
-    position === "horizontal"
-        ? handleHorizontalUnits(unit)
-        : handleVerticalUnits(unit);
+const handleUnits = (
+    unit: string,
+    position: "vertical" | "horizontal",
+    direction: "row" | "column"
+) => {
+    if (unit === "pixels") {
+        return "px";
+    } else {
+        return unitTree[position][direction][unit];
+    }
+};
 
 /**
  * If the values and units are not undefined, then map over the values and units and join them together
@@ -45,7 +66,8 @@ const handleUnits = (unit: string, position: "vertical" | "horizontal") =>
  */
 const handlePositionalRule = (
     values: Array<number | undefined>,
-    units: Array<string | undefined>
+    units: Array<string | undefined>,
+    direction: "row" | "column"
 ) => {
     if (!values || !units) {
         return "auto";
@@ -55,14 +77,17 @@ const handlePositionalRule = (
                 (value, index) =>
                     `${value || 0}${handleUnits(
                         units[index] || "",
-                        index % 2 === 0 ? "vertical" : "horizontal"
+                        index % 2 === 0 ? "vertical" : "horizontal",
+                        direction
                     )}`
             )
             .join(" ");
     }
 };
 
-const LinearPane: React.FC<PanePosition> = ({
+const LinearPane: React.FC<
+    PanePosition & { allowOverflow?: boolean; direction?: "row" | "column" }
+> = ({
     width,
     height,
     layer,
@@ -76,18 +101,44 @@ const LinearPane: React.FC<PanePosition> = ({
     padUnitsRight,
     padUnitsBottom,
     padUnitsTop,
-    children
+    children,
+    allowOverflow,
+    direction
 }) => {
     return (
         <View
-            width={`${width}${handleHorizontalUnits(widthUnits)}`}
-            height={`${height}${handleVerticalUnits(heightUnits)}`}
+            width={`${width}${handleUnits(
+                widthUnits,
+                "horizontal",
+                direction
+            )}`}
+            height={`${height}${handleUnits(
+                heightUnits,
+                "vertical",
+                direction
+            )}`}
             maxWidth={"100%"}
             zIndex={layer}
-            paddingBottom={`${padBottom}${handleVerticalUnits(padUnitsBottom)}`}
-            paddingStart={`${padLeft}${handleVerticalUnits(padUnitsLeft)}`}
-            paddingEnd={`${padRight}${handleVerticalUnits(padUnitsRight)}`}
-            paddingTop={`${padTop}${handleVerticalUnits(padUnitsTop)}`}
+            paddingBottom={`${padBottom}${handleUnits(
+                padUnitsBottom,
+                "vertical",
+                direction
+            )}`}
+            paddingStart={`${padLeft}${handleUnits(
+                padUnitsLeft,
+                "horizontal",
+                direction
+            )}`}
+            paddingEnd={`${padRight}${handleUnits(
+                padUnitsRight,
+                "horizontal",
+                direction
+            )}`}
+            paddingTop={`${padTop}${handleUnits(
+                padUnitsTop,
+                "vertical",
+                direction
+            )}`}
             UNSAFE_style={{
                 transition:
                     "bottom 250ms, left 250ms, width 250ms, height 250ms, background 250ms",
@@ -95,6 +146,7 @@ const LinearPane: React.FC<PanePosition> = ({
                     "0px 10px 15px -3px rgba(0,0,0,0.1),3px -7px 15px -3px rgba(0,0,0,0.05)",
                 boxSizing: "border-box"
             }}
+            flexShrink={allowOverflow ? 0 : 1}
         >
             {children}
         </View>
@@ -106,40 +158,62 @@ export interface MaticoLinearLayoutInterface {
     direction: LinearLayoutDirection;
     align: Alignment;
     justify: Justification;
-    gap? : GapSize
+    gap?: GapSize;
+    allowOverflow?: boolean;
 }
 
-const GapVals ={
-  "none" : "size-0",
-  "small": "size-100",
-  "medium":"size-600",
-  "large":"size-1000"
-
-}
+const GapVals = {
+    none: "size-0",
+    small: "size-100",
+    medium: "size-600",
+    large: "size-1000"
+};
 
 export const MaticoLinearLayout: React.FC<MaticoLinearLayoutInterface> = ({
     paneRefs,
     direction,
     align,
     justify,
-    gap
+    gap,
+    allowOverflow
 }) => {
     return (
-        <Flex
-            position="relative"
+        <View
             width="100%"
             height="100%"
-            direction={direction}
-            alignContent={align}
-            justifyContent={justify}
-            gap={GapVals[gap]}
+            overflow={`${allowOverflow && direction === "row" ? "auto" : "hidden"} ${allowOverflow && direction === "column" ? "auto" : "hidden"}
+            `}
         >
-            {paneRefs.map((paneRef: PaneRef) => (
-                <LinearPane key={paneRef.id} {...paneRef.position}>
-                    <ControlActionBar paneRef={paneRef} />
-                    <PaneSelector paneRef={paneRef} />
-                </LinearPane>
-            ))}
-        </Flex>
+            <Flex
+                id="layout-engine"
+                position="relative"
+                width={
+                    allowOverflow && direction === "row"
+                        ? "fit-content"
+                        : "100%"
+                }
+                height={
+                    allowOverflow && direction === "column"
+                        ? "fit-content"
+                        : "100%"
+                }
+                direction={direction}
+                alignContent={align}
+                justifyContent={justify}
+                gap={GapVals[gap]}
+            >
+                {paneRefs.map((paneRef: PaneRef) => (
+                    <LinearPane
+                        key={paneRef.id}
+                        allowOverflow={allowOverflow}
+                        direction={direction}
+                        {...paneRef.position}
+                    >
+                        {/* <ControlActionBar paneRef={paneRef} /> */}
+                        <PaneSelector paneRef={paneRef} />
+                    </LinearPane>
+                ))}
+            </Flex>
+        </View>
     );
 };

--- a/matico_components/src/Components/MaticoEditor/Panes/ContainerPaneEditor.tsx
+++ b/matico_components/src/Components/MaticoEditor/Panes/ContainerPaneEditor.tsx
@@ -17,8 +17,7 @@ export interface SectionEditorProps {
 export const ContainerPaneEditor: React.FC<SectionEditorProps> = ({
     paneRef
 }) => {
-    const { container, removePane, updatePane, updatePanePosition, parent } =
-        useContainer(paneRef);
+    const { container, removePane, updatePane, updatePanePosition, parent } = useContainer(paneRef);
 
     return (
         <Flex width="100%" height="100%" direction="column">

--- a/matico_components/src/Components/MaticoEditor/Panes/LayoutEditor.tsx
+++ b/matico_components/src/Components/MaticoEditor/Panes/LayoutEditor.tsx
@@ -42,6 +42,20 @@ export const LinearLayoutEditor: React.FC<LinearLayoutEditorProps> = ({
                     <Radio value="column">Vertical</Radio>
                 </Flex>
             </RadioGroup>
+            <RadioGroup
+                label="Fit content to container"
+                value={layout.allowOverflow ? "allow" : "noAllow"}
+                onChange={(stringVal) =>
+                    onChange({
+                        allowOverflow: stringVal === "allow" ? true : false
+                    })
+                }
+            >
+                <Flex direction="row">
+                    <Radio value={"allow"}>Overflow content</Radio>
+                    <Radio value={"noAllow"}>Fit to container</Radio>
+                </Flex>
+            </RadioGroup>
 
             <Picker
                 label="Gap"
@@ -57,61 +71,72 @@ export const LinearLayoutEditor: React.FC<LinearLayoutEditorProps> = ({
             >
                 {(item) => <Item key={item.id}>{item.label}</Item>}
             </Picker>
+            {!layout.allowOverflow && (
+                <>
+                    <RadioGroup
+                        label="Flow Alignment"
+                        value={layout.align}
+                        onChange={(val) =>
+                            onChange({ align: val as Alignment })
+                        }
+                    >
+                        <Flex direction="row" wrap={"wrap"}>
+                            <Radio value="start">Start</Radio>
+                            <Radio value="center">Center</Radio>
+                            <Radio value="end">End</Radio>
+                            <Radio value="stretch">Stretch</Radio>
+                            <Radio value="baseline">Baseline</Radio>
+                        </Flex>
+                    </RadioGroup>
 
-            <RadioGroup
-                label="Flow Alignment"
-                value={layout.align}
-                onChange={(val) => onChange({ align: val as Alignment })}
-            >
-                <Flex direction="row" wrap={"wrap"}>
-                    <Radio value="start">Start</Radio>
-                    <Radio value="center">Center</Radio>
-                    <Radio value="end">End</Radio>
-                    <Radio value="stretch">Stretch</Radio>
-                    <Radio value="baseline">Baseline</Radio>
-                </Flex>
-            </RadioGroup>
-
-            <RadioGroup
-                label="Flow Justification"
-                value={layout.justify}
-                onChange={(val) => onChange({ justify: val as Justification })}
-            >
-                <Flex direction="row" wrap={"wrap"}>
-                    <Radio value="start">Start</Radio>
-                    <Radio value="center">Center</Radio>
-                    <Radio value="end">End</Radio>
-                    <Radio value="space-between">Space Between</Radio>
-                    <Radio value="space-around">Space Around</Radio>
-                    <Radio value="space-evenly">Space Evenly</Radio>
-                </Flex>
-            </RadioGroup>
+                    <RadioGroup
+                        label="Flow Justification"
+                        value={layout.justify}
+                        onChange={(val) =>
+                            onChange({ justify: val as Justification })
+                        }
+                    >
+                        <Flex direction="row" wrap={"wrap"}>
+                            <Radio value="start">Start</Radio>
+                            <Radio value="center">Center</Radio>
+                            <Radio value="end">End</Radio>
+                            <Radio value="space-between">Space Between</Radio>
+                            <Radio value="space-around">Space Around</Radio>
+                            <Radio value="space-evenly">Space Evenly</Radio>
+                        </Flex>
+                    </RadioGroup>
+                </>
+            )}
         </Flex>
     );
 };
 
-export interface TabLayoutEditorProps{
-  layout: TabLayout,
-  onChange:(update:Partial<TabLayout>)=>void
+export interface TabLayoutEditorProps {
+    layout: TabLayout;
+    onChange: (update: Partial<TabLayout>) => void;
 }
 
-export const TabLayoutEditor: React.FC<TabLayoutEditorProps>  = ({layout,onChange})=>{
-  return(
-    <Flex direction='column' width="100%">
+export const TabLayoutEditor: React.FC<TabLayoutEditorProps> = ({
+    layout,
+    onChange
+}) => {
+    return (
+        <Flex direction="column" width="100%">
             <RadioGroup
                 label="Tab bar location"
                 value={layout.tabBarPosition}
-                onChange={(val) => onChange({ tabBarPosition: val as TabBarPosition})}
+                onChange={(val) =>
+                    onChange({ tabBarPosition: val as TabBarPosition })
+                }
             >
                 <Flex direction="row" wrap={"wrap"}>
                     <Radio value="horizontal">Horizontal</Radio>
                     <Radio value="vertical">Vertical</Radio>
                 </Flex>
             </RadioGroup>
-    </Flex>
-  )
-}
-
+        </Flex>
+    );
+};
 
 export interface FreeLayoutEditorProps {
     layout: FreeLayout;

--- a/matico_components/src/Components/MaticoEditor/Panes/PageEditor.tsx
+++ b/matico_components/src/Components/MaticoEditor/Panes/PageEditor.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import _ from "lodash";
-import "react-mde/lib/styles/css/react-mde-all.css";
+// import "react-mde/lib/styles/css/react-mde-all.css";
 import {
     ComboBox,
     Flex,

--- a/matico_components/src/Components/MaticoEditor/Utils/PaneDetails.tsx
+++ b/matico_components/src/Components/MaticoEditor/Utils/PaneDetails.tsx
@@ -203,7 +203,7 @@ export const containerPreset = (name: string, presetType: ContainerPresetTypes) 
         id:uuid(),
         name:name,
         type: 'container',
-        layout: {type:"linear", gap:"small", direction:"row", justify:'start', align:"center", allowOverflow:false},
+        layout: {type:"linear", gap:"small", direction:"row", justify:'start', align:"center", allowOverflow:true},
         panes:[]
       }
       return {container: rowContainer, additionalPanes:[]}
@@ -213,7 +213,7 @@ export const containerPreset = (name: string, presetType: ContainerPresetTypes) 
         id:uuid(),
         name:name,
         type: 'container',
-        layout: {type:"linear", gap:"small", direction:"column", justify:'start', align:"center", allowOverflow:false},
+        layout: {type:"linear", gap:"small", direction:"column", justify:'start', align:"center", allowOverflow:true},
         panes:[]
       }
       return {container: columnContainer, additionalPanes:[]}

--- a/matico_components/src/Components/MaticoPage/MaticoPage.tsx
+++ b/matico_components/src/Components/MaticoPage/MaticoPage.tsx
@@ -13,7 +13,7 @@ export const MaticoPage: React.FC<MaticoPageInterface> = ({ pageId }) => {
     let LayoutEngine = selectLayout(layout);
 
     return (
-        <View overflow="none auto" width="100%" height="100%">
+        <View overflow="none auto" width="100%" height="100%" id="xxx">
             <Flex direction="column" width={"100%"} height={"100%"}>
                 <LayoutEngine paneRefs={page?.panes} />
             </Flex>

--- a/matico_components/src/Components/Panes/MaticoTextPane/MaticoTextPane.tsx
+++ b/matico_components/src/Components/Panes/MaticoTextPane/MaticoTextPane.tsx
@@ -17,6 +17,7 @@ const TextPaneContainer = styled.section<{isReadOnly?:boolean}>`
     height: 100%;
     div.editor-shell {
         margin:0;
+        max-width:initial;
     }
     div.editor-shell, div.editor-container {
         height: 100%;

--- a/matico_components/src/Utils/paneEngine.tsx
+++ b/matico_components/src/Utils/paneEngine.tsx
@@ -40,7 +40,13 @@ const Wrapper = styled.button<{ interactive?: boolean; isHovered?: boolean }>`
     width: 100%;
     height: 100%;
     box-sizing: border-box;
-    &:after {
+    transition:125ms all;
+    border: ${({ isHovered }) =>
+        isHovered
+            ? "4px solid var(--spectrum-global-color-chartreuse-500)"
+            : "none"};
+    /* padding: -4px; */
+    /* &:after {
         box-sizing: border-box;
         content: "";
         display: block;
@@ -53,11 +59,7 @@ const Wrapper = styled.button<{ interactive?: boolean; isHovered?: boolean }>`
         z-index: 1;
         border: 2px solid rgba(0, 0, 0, 0);
         transition: border 125ms;
-        border: ${({ isHovered }) =>
-            isHovered
-                ? "4px solid var(--spectrum-global-color-chartreuse-500)"
-                : "4px solid rgba(0,0,0,0)"};
-    }
+    } */
     pointer-events: ${({ interactive }) => (interactive ? "all" : "none")};
     cursor: ${({ interactive }) => (interactive ? "pointer" : "default")};
     * {


### PR DESCRIPTION
## Overview

This PR adds scrollable and flex option controls for linear panes (rows and columns). This was already in the spec, but you can now have a scrolling vertical or horizontal pane (default) or a flex pane that locks up the elements to the dimension of the container.

Additionally, this PR cleans up some unit selection functions for more intuitive sizing.
- In a column, % width is % of the parent and % height is percent of the viewport
- In a row, % width is % of the viewport and % height is percent of the parent

## Testing Instructions

* Run editor
* Add linear pane