### PR TITLE
Create CODEOWNERS File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist/
 .netlify
 matico_charts/package-lock.json
 .vscode/settings.json
+.idea/
 matico_spec/bindings
 
 bindings

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # This can be modified to be more specific as time goes on, but for the
 # time being we can have it to where at least any PR submitted has
 # all of our accounts attached to it as default reviewers.
-@nofurtherinformation @stuartlynn @michplunkett
+*   @nofurtherinformation @stuartlynn @michplunkett

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# This can be modified to be more specific as time goes on, but for the
+# time being we can have it to where at least any PR submitted has
+# all of our accounts attached to it as default reviewers.
+@nofurtherinformation @stuartlynn @michplunkett


### PR DESCRIPTION
## Overview

This file makes it so that any created PR will have all three of the users listed in it automatically show up as assigned reviewers. As time goes on we can get more specific with who has say over x or y package, language, etc., but for the time being this be a nice QoL addition.

`CODEOWNERS` about page: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners