### PR TITLE
Apply Rust formatting

### DIFF
--- a/matico_common/src/compute/errors.rs
+++ b/matico_common/src/compute/errors.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize,Deserialize};
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -26,13 +26,15 @@ impl fmt::Display for ArgError {
     }
 }
 
-impl From<ArgError> for ProcessError{
-    fn from (arg_err: ArgError) ->Self{
-       ProcessError { error: format!("{:#?}",arg_err) } 
-    } 
+impl From<ArgError> for ProcessError {
+    fn from(arg_err: ArgError) -> Self {
+        ProcessError {
+            error: format!("{:#?}", arg_err),
+        }
+    }
 }
 
-#[derive(Serialize,Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ProcessError {
-    pub error: String
+    pub error: String,
 }

--- a/matico_common/src/compute/mod.rs
+++ b/matico_common/src/compute/mod.rs
@@ -1,8 +1,7 @@
 pub mod errors;
 pub mod options;
-pub mod variables; 
+pub mod variables;
 
 pub use errors::*;
 pub use options::*;
 pub use variables::*;
-

--- a/matico_common/src/compute/options.rs
+++ b/matico_common/src/compute/options.rs
@@ -1,36 +1,34 @@
 use std::collections::BTreeMap;
 
-use enum_dispatch::enum_dispatch;
-use serde::{Serialize,Deserialize};
 use crate::compute::variables::ParameterValue;
+use enum_dispatch::enum_dispatch;
+use serde::{Deserialize, Serialize};
 use ts_rs::TS;
-
 
 #[enum_dispatch]
 pub trait ValidateParameter {
     fn validate_parameter(&self, value: &ParameterValue) -> Result<(), String>;
 }
 
-#[derive(Serialize,Deserialize,TS)]
-#[serde(rename_all="camelCase")]
+#[derive(Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct ParameterOptionDisplayDetails{
+pub struct ParameterOptionDisplayDetails {
     pub description: Option<String>,
-    pub display_name: Option<String>
+    pub display_name: Option<String>,
 }
 
-impl Default for ParameterOptionDisplayDetails{
+impl Default for ParameterOptionDisplayDetails {
     fn default() -> Self {
-        Self{
-            description:None,
-            display_name:None
+        Self {
+            description: None,
+            display_name: None,
         }
     }
 }
 
-
-#[derive(Serialize,Deserialize,TS)]
-#[serde(rename_all="camelCase" )]
+#[derive(Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub enum ColType {
     Text,
@@ -38,13 +36,13 @@ pub enum ColType {
     Geometry,
 }
 
-#[derive(Serialize,Deserialize,TS)]
-#[serde(rename_all="camelCase")]
+#[derive(Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct NumericFloatOptions {
     pub range: Option<[f32; 2]>,
     pub default: Option<f32>,
-    pub display_details: ParameterOptionDisplayDetails
+    pub display_details: ParameterOptionDisplayDetails,
 }
 
 impl ValidateParameter for NumericFloatOptions {
@@ -70,17 +68,21 @@ impl ValidateParameter for NumericFloatOptions {
 
 impl Default for NumericFloatOptions {
     fn default() -> Self {
-        Self { range: None , default:None, display_details: Default::default()}
+        Self {
+            range: None,
+            default: None,
+            display_details: Default::default(),
+        }
     }
 }
 
-#[derive(Serialize,Deserialize,TS)]
-#[serde(rename_all="camelCase")]
+#[derive(Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct NumericIntOptions {
     pub range: Option<[i32; 2]>,
     pub default: Option<i32>,
-    pub display_details: ParameterOptionDisplayDetails
+    pub display_details: ParameterOptionDisplayDetails,
 }
 
 impl ValidateParameter for NumericIntOptions {
@@ -106,17 +108,21 @@ impl ValidateParameter for NumericIntOptions {
 
 impl Default for NumericIntOptions {
     fn default() -> Self {
-        Self { range: None, default:None, display_details: Default::default()}
+        Self {
+            range: None,
+            default: None,
+            display_details: Default::default(),
+        }
     }
 }
 
-#[derive(Serialize,Deserialize,TS)]
-#[serde(rename_all="camelCase")]
+#[derive(Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct NumericCategoryOptions {
     pub allow_multi: bool,
     pub options: Vec<u32>,
-    pub display_details: ParameterOptionDisplayDetails
+    pub display_details: ParameterOptionDisplayDetails,
 }
 
 impl ValidateParameter for NumericCategoryOptions {
@@ -140,18 +146,18 @@ impl Default for NumericCategoryOptions {
         Self {
             allow_multi: false,
             options: vec![],
-            display_details: Default::default()
+            display_details: Default::default(),
         }
     }
 }
 
-#[derive(Serialize,Deserialize,TS)]
-#[serde(rename_all="camelCase")]
+#[derive(Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct TextCategoryOptions {
     pub allow_multi: bool,
     pub options: Vec<String>,
-    pub display_details: ParameterOptionDisplayDetails
+    pub display_details: ParameterOptionDisplayDetails,
 }
 
 impl Default for TextCategoryOptions {
@@ -159,7 +165,7 @@ impl Default for TextCategoryOptions {
         Self {
             allow_multi: false,
             options: vec![],
-            display_details: Default::default()
+            display_details: Default::default(),
         }
     }
 }
@@ -180,13 +186,13 @@ impl ValidateParameter for TextCategoryOptions {
     }
 }
 
-#[derive(Serialize,Deserialize,TS)]
-#[serde(rename_all="camelCase")]
+#[derive(Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct ColumnOptions {
     pub allowed_column_types: Option<Vec<ColType>>,
     pub from_dataset: String,
-    pub display_details: ParameterOptionDisplayDetails
+    pub display_details: ParameterOptionDisplayDetails,
 }
 
 impl Default for ColumnOptions {
@@ -194,7 +200,7 @@ impl Default for ColumnOptions {
         Self {
             allowed_column_types: Some(vec![ColType::Text, ColType::Numeric, ColType::Geometry]),
             from_dataset: "".into(),
-            display_details: Default::default()
+            display_details: Default::default(),
         }
     }
 }
@@ -206,20 +212,19 @@ impl ValidateParameter for ColumnOptions {
     }
 }
 
-
-#[derive(Serialize,Deserialize,TS)]
-#[serde(rename_all="camelCase")]
+#[derive(Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct TableOptions {
     pub must_have_geom: bool,
-    pub display_details : ParameterOptionDisplayDetails
+    pub display_details: ParameterOptionDisplayDetails,
 }
 
 impl Default for TableOptions {
     fn default() -> Self {
         Self {
             must_have_geom: false,
-            display_details: Default::default()
+            display_details: Default::default(),
         }
     }
 }
@@ -231,58 +236,56 @@ impl ValidateParameter for TableOptions {
     }
 }
 
-#[derive(Serialize,Deserialize,TS)]
-#[serde(rename_all="camelCase")]
+#[derive(Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct TextOptions {
     pub max_length: Option<usize>,
     pub display_details: ParameterOptionDisplayDetails,
-    pub default: Option<String> 
-
+    pub default: Option<String>,
 }
 
 impl Default for TextOptions {
     fn default() -> Self {
-        Self { 
+        Self {
             max_length: None,
             display_details: Default::default(),
-            default: None
+            default: None,
         }
     }
 }
 
-#[derive(Serialize,Deserialize,TS)]
-#[serde(rename_all="camelCase")]
+#[derive(Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct OptionGroup{
-    pub options: BTreeMap<String,ParameterOptions>,
+pub struct OptionGroup {
+    pub options: BTreeMap<String, ParameterOptions>,
     pub display_details: ParameterOptionDisplayDetails,
 }
 
 // TODO implment
-impl ValidateParameter for OptionGroup{
+impl ValidateParameter for OptionGroup {
     fn validate_parameter(&self, value: &ParameterValue) -> Result<(), String> {
         Ok(())
     }
 }
 
 // TODO implment
-impl ValidateParameter for RepeatedOption{
+impl ValidateParameter for RepeatedOption {
     fn validate_parameter(&self, value: &ParameterValue) -> Result<(), String> {
         Ok(())
     }
 }
 
-#[derive(Serialize,Deserialize,TS)]
-#[serde(rename_all="camelCase")]
+#[derive(Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct RepeatedOption{
+pub struct RepeatedOption {
     pub options: Box<ParameterOptions>,
     pub display_details: ParameterOptionDisplayDetails,
     pub min_times: usize,
     pub max_times: Option<usize>,
 }
-
 
 // TODO figure out how to validate this against table
 impl ValidateParameter for TextOptions {
@@ -307,8 +310,8 @@ impl ValidateParameter for TextOptions {
 }
 
 #[enum_dispatch(ValidateParameter)]
-#[derive(Serialize,Deserialize,TS)]
-#[serde(rename_all="camelCase", tag="type")]
+#[derive(Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase", tag = "type")]
 #[ts(export)]
 pub enum ParameterOptions {
     OptionGroup(OptionGroup),

--- a/matico_common/src/compute/variables.rs
+++ b/matico_common/src/compute/variables.rs
@@ -1,32 +1,37 @@
-use serde::{Serialize,Deserialize};
 use crate::VarOr;
-use ts_rs::TS;
+use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
+use ts_rs::TS;
 
 use crate::{ArgError, ProcessError};
 
-#[derive(Serialize,Deserialize,Debug, Clone, TS)]
+#[derive(Serialize, Deserialize, Debug, Clone, TS)]
 #[ts(export)]
 pub struct OptionGroupVals(Vec<OptionGroupVal>);
 
-#[derive(Serialize,Deserialize,Debug, Clone, TS)]
-#[serde(rename_all="camelCase")]
+#[derive(Serialize, Deserialize, Debug, Clone, TS)]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct OptionGroupVal{
-    pub name:String,
-    pub parameter: ParameterValue
+pub struct OptionGroupVal {
+    pub name: String,
+    pub parameter: ParameterValue,
 }
 
-impl OptionGroupVals{
-    pub fn get(&self, variable: &str)->Result<&ParameterValue, ProcessError>{
-        let option_group = self.0.iter().find(|v| v.name == variable).ok_or_else(|| ProcessError{error:format!("Failed to get {} in option group", variable).into()})?;
+impl OptionGroupVals {
+    pub fn get(&self, variable: &str) -> Result<&ParameterValue, ProcessError> {
+        let option_group =
+            self.0
+                .iter()
+                .find(|v| v.name == variable)
+                .ok_or_else(|| ProcessError {
+                    error: format!("Failed to get {} in option group", variable).into(),
+                })?;
         Ok(&option_group.parameter)
     }
 }
 
-
-#[derive(Serialize,Deserialize,Debug, Clone, TS)]
-#[serde(rename_all="camelCase", tag="type",content="value")]
+#[derive(Serialize, Deserialize, Debug, Clone, TS)]
+#[serde(rename_all = "camelCase", tag = "type", content = "value")]
 #[ts(export)]
 pub enum ParameterValue {
     OptionGroup(OptionGroupVals),
@@ -40,109 +45,109 @@ pub enum ParameterValue {
     Text(String),
 }
 
-
-impl TryFrom<&ParameterValue> for Vec<ParameterValue>{
+impl TryFrom<&ParameterValue> for Vec<ParameterValue> {
     type Error = ArgError;
 
-    fn try_from(parameter_value: &ParameterValue) -> Result<Vec<ParameterValue>, Self::Error>{
-        if let ParameterValue::RepeatedOption(list) = parameter_value{
-            return Ok(list.to_owned())
-        }
-        else{
-            Err(ArgError::new("", "Failed to convert ParameterValue to options"))
+    fn try_from(parameter_value: &ParameterValue) -> Result<Vec<ParameterValue>, Self::Error> {
+        if let ParameterValue::RepeatedOption(list) = parameter_value {
+            return Ok(list.to_owned());
+        } else {
+            Err(ArgError::new(
+                "",
+                "Failed to convert ParameterValue to options",
+            ))
         }
     }
 }
 
-impl TryFrom<&ParameterValue> for OptionGroupVals{
+impl TryFrom<&ParameterValue> for OptionGroupVals {
     type Error = ArgError;
 
-    fn try_from(parameter_value: &ParameterValue)->Result<OptionGroupVals, Self::Error>{
-        if let ParameterValue::OptionGroup(options) = parameter_value{
-            return Ok(options.to_owned())
-        }
-        else{
-            Err(ArgError::new("", "Failed to convert ParameterValue to options"))
+    fn try_from(parameter_value: &ParameterValue) -> Result<OptionGroupVals, Self::Error> {
+        if let ParameterValue::OptionGroup(options) = parameter_value {
+            return Ok(options.to_owned());
+        } else {
+            Err(ArgError::new(
+                "",
+                "Failed to convert ParameterValue to options",
+            ))
         }
     }
 }
 
-impl TryFrom<&ParameterValue> for f32{
+impl TryFrom<&ParameterValue> for f32 {
     type Error = ArgError;
 
-    fn try_from(parameter_value: &ParameterValue)-> Result<f32, Self::Error>{
-        if let ParameterValue::NumericFloat(val) = parameter_value{
-            return Ok(*val)
-        }
-        else{
+    fn try_from(parameter_value: &ParameterValue) -> Result<f32, Self::Error> {
+        if let ParameterValue::NumericFloat(val) = parameter_value {
+            return Ok(*val);
+        } else {
             Err(ArgError::new("", "Failed to convert ParameterValue to f64"))
         }
     }
-} 
-
-impl TryFrom<&ParameterValue> for i32{
-    type Error = ArgError;
-
-    fn try_from(parameter_value: &ParameterValue)-> Result<i32, Self::Error>{
-        if let ParameterValue::NumericInt(val) = parameter_value{
-            return Ok(*val)
-        }
-        else{
-            Err(ArgError::new("", "Failed to convert ParameterValue to i32"))
-        }
-    }
-} 
-
-impl TryFrom<&ParameterValue> for u32{
-    type Error = ArgError;
-
-    fn try_from(parameter_value: &ParameterValue)-> Result<u32, Self::Error>{
-        if let ParameterValue::NumericInt(val) = parameter_value{
-            return Ok(*val as u32)
-        }
-        else{
-            Err(ArgError::new("", "Failed to convert ParameterValue to i32"))
-        }
-    }
-} 
-
-impl TryFrom<&ParameterValue> for Vec<u32>{
-    type Error = ArgError;
-
-    fn try_from(parameter_value: &ParameterValue)-> Result<Vec<u32>, Self::Error>{
-        if let ParameterValue::NumericCategory(val) = parameter_value{
-            return Ok(val.clone())
-        }
-        else{
-            Err(ArgError::new("", "Failed to convert Numeric Category ParameterValue to  u32"))
-        }
-    }
-} 
-
-impl TryFrom<&ParameterValue> for String{
-    type Error = ArgError;
-    fn try_from(parameter_value: &ParameterValue)-> Result<String, Self::Error>{
-        match parameter_value{
-            ParameterValue::Column(s)=>Ok(s.clone()),
-            ParameterValue::Table(s)=>Ok(s.clone()),
-            ParameterValue::Text(s) =>Ok(s.clone()),
-            _ => Err(ArgError::new("", "Failed to convert ParameterValue to i32"))
-        }
-    }
-} 
-
-#[derive(Serialize,Deserialize,Debug, Clone, TS)]
-#[serde(rename_all="camelCase")]
-#[ts(export)]
-pub struct SpecParameter{
-    name: String,
-    parameter: SpecParameterValue
 }
 
+impl TryFrom<&ParameterValue> for i32 {
+    type Error = ArgError;
 
+    fn try_from(parameter_value: &ParameterValue) -> Result<i32, Self::Error> {
+        if let ParameterValue::NumericInt(val) = parameter_value {
+            return Ok(*val);
+        } else {
+            Err(ArgError::new("", "Failed to convert ParameterValue to i32"))
+        }
+    }
+}
 
-#[derive(Serialize,Deserialize,Debug, Clone, TS)]
-#[serde(rename_all="camelCase", tag="type", content="value")]
+impl TryFrom<&ParameterValue> for u32 {
+    type Error = ArgError;
+
+    fn try_from(parameter_value: &ParameterValue) -> Result<u32, Self::Error> {
+        if let ParameterValue::NumericInt(val) = parameter_value {
+            return Ok(*val as u32);
+        } else {
+            Err(ArgError::new("", "Failed to convert ParameterValue to i32"))
+        }
+    }
+}
+
+impl TryFrom<&ParameterValue> for Vec<u32> {
+    type Error = ArgError;
+
+    fn try_from(parameter_value: &ParameterValue) -> Result<Vec<u32>, Self::Error> {
+        if let ParameterValue::NumericCategory(val) = parameter_value {
+            return Ok(val.clone());
+        } else {
+            Err(ArgError::new(
+                "",
+                "Failed to convert Numeric Category ParameterValue to  u32",
+            ))
+        }
+    }
+}
+
+impl TryFrom<&ParameterValue> for String {
+    type Error = ArgError;
+    fn try_from(parameter_value: &ParameterValue) -> Result<String, Self::Error> {
+        match parameter_value {
+            ParameterValue::Column(s) => Ok(s.clone()),
+            ParameterValue::Table(s) => Ok(s.clone()),
+            ParameterValue::Text(s) => Ok(s.clone()),
+            _ => Err(ArgError::new("", "Failed to convert ParameterValue to i32")),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub struct SpecParameter {
+    name: String,
+    parameter: SpecParameterValue,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, TS)]
+#[serde(rename_all = "camelCase", tag = "type", content = "value")]
 #[ts(export)]
 pub enum SpecParameterValue {
     OptionGroup(Vec<SpecParameter>),

--- a/matico_common/src/filters.rs
+++ b/matico_common/src/filters.rs
@@ -1,9 +1,9 @@
 use crate::{AutoComplete, VarOr};
+use chrono::{DateTime, Utc};
 use matico_spec_derive::AutoCompleteMe;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 use validator::Validate;
-use chrono::{DateTime, Utc};
 
 #[derive(Serialize, Clone, Deserialize, Validate, Debug, Default, AutoCompleteMe, TS)]
 #[serde(rename_all = "camelCase")]
@@ -14,25 +14,24 @@ pub struct RangeFilter {
     max: Option<VarOr<f32>>,
 }
 
-#[derive(Serialize, Clone, Deserialize, Validate, Debug,  AutoCompleteMe, TS)]
+#[derive(Serialize, Clone, Deserialize, Validate, Debug, AutoCompleteMe, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct DateFilter{
+pub struct DateFilter {
     variable: String,
     min: Option<DateTime<Utc>>,
-    max: Option<DateTime<Utc>>
+    max: Option<DateTime<Utc>>,
 }
 
-impl Default for DateFilter{
+impl Default for DateFilter {
     fn default() -> Self {
-        Self{
+        Self {
             min: None,
             max: None,
-            variable: "".into()
+            variable: "".into(),
         }
     }
 }
-
 
 #[derive(Serialize, Clone, Deserialize, Validate, Debug, Default, AutoCompleteMe, TS)]
 #[serde(rename_all = "camelCase")]
@@ -46,9 +45,9 @@ pub struct CategoryFilter {
 #[derive(Serialize, Clone, Deserialize, Validate, Debug, Default, AutoCompleteMe, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct RegExFilter{
+pub struct RegExFilter {
     variable: String,
-    regex:String
+    regex: String,
 }
 
 #[derive(Serialize, Clone, Deserialize, Debug, AutoCompleteMe, TS)]
@@ -59,7 +58,7 @@ pub enum Filter {
     Range(RangeFilter),
     Category(CategoryFilter),
     Date(DateFilter),
-    RegEx(RegExFilter)
+    RegEx(RegExFilter),
 }
 
 impl Default for Filter {

--- a/matico_common/src/lib.rs
+++ b/matico_common/src/lib.rs
@@ -1,10 +1,9 @@
 pub mod autocomplete;
+pub mod compute;
 pub mod filters;
 pub mod variables;
-pub mod compute;
-
 
 pub use autocomplete::*;
+pub use compute::*;
 pub use filters::*;
 pub use variables::*;
-pub use compute::*;

--- a/matico_compute/matico_analysis/src/lib.rs
+++ b/matico_compute/matico_analysis/src/lib.rs
@@ -1,8 +1,8 @@
 use geo::Geometry;
 use geozero::{wkb::Wkb, ToGeo};
-use std::collections::BTreeMap;
-pub use polars::prelude::{Series, DataFrame};
 pub use matico_common::*;
+pub use polars::prelude::{DataFrame, Series};
+use std::collections::BTreeMap;
 
 pub trait MaticoAnalysis {
     fn get_parameter(&self, param_name: &str) -> Result<&ParameterValue, ArgError>;
@@ -10,10 +10,10 @@ pub trait MaticoAnalysis {
     fn register_table(&mut self, name: &str, data: &[u8]) -> Result<(), ArgError>;
 }
 
-pub trait MaticoAnalysisRunner{
+pub trait MaticoAnalysisRunner {
     fn options() -> BTreeMap<String, ParameterOptions>;
     fn run(&mut self) -> Result<DataFrame, ProcessError>;
-    fn description()-> Option<String>;
+    fn description() -> Option<String>;
 }
 
 pub fn iter_geom(series: &Series) -> impl Iterator<Item = Geometry<f64>> + '_ {
@@ -25,4 +25,4 @@ pub fn iter_geom(series: &Series) -> impl Iterator<Item = Geometry<f64>> + '_ {
         let vec: Vec<u8> = buffer.into_iter().map(|x| x.unwrap()).collect();
         Wkb(vec).to_geo().expect("unable to convert to geo")
     })
-} 
+}

--- a/matico_compute/matico_synthetic_data_analysis/src/lib.rs
+++ b/matico_compute/matico_synthetic_data_analysis/src/lib.rs
@@ -1,27 +1,25 @@
-use geo::{Geometry,Point};
+use geo::{Geometry, Point};
 use geopolars::geoseries::GeoSeries;
 use matico_analysis::*;
-use matico_common::{ProcessError, ArgError};
-use polars::io::{SerWriter, SerReader};
+use matico_common::{ArgError, ProcessError};
+use polars::io::{SerReader, SerWriter};
 use polars::prelude::NamedFromOwned;
 use rand::Rng;
+use rand_distr::{Binomial, Distribution, Normal, Poisson};
 use serde::{Deserialize, Serialize};
-use std::convert::TryInto;
 use std::collections::{BTreeMap, HashMap};
+use std::convert::TryInto;
 use wasm_bindgen::prelude::*;
-use rand_distr::{Normal,Distribution, Binomial, Poisson};
-
 
 #[matico_spec_derive::matico_compute]
-pub struct SyntheticData{}
+pub struct SyntheticData {}
 
-impl MaticoAnalysisRunner for SyntheticData{
+impl MaticoAnalysisRunner for SyntheticData {
     fn run(&mut self) -> std::result::Result<DataFrame, ProcessError> {
-        
         // Get region variables
         let region: OptionGroupVals = self.get_parameter("region")?.try_into()?;
         let min_lat: f32 = region.get("min_lat")?.try_into()?;
-        let max_lat: f32  = region.get("max_lat")?.try_into()?;
+        let max_lat: f32 = region.get("max_lat")?.try_into()?;
         let min_lng: f32 = region.get("min_lng")?.try_into()?;
         let max_lng: f32 = region.get("max_lng")?.try_into()?;
 
@@ -30,274 +28,331 @@ impl MaticoAnalysisRunner for SyntheticData{
         let no_points: u32 = outcome.get("no_points")?.try_into()?;
         let control_fraction: f32 = outcome.get("control_fraction")?.try_into()?;
         let intercept: f32 = outcome.get("intercept")?.try_into()?;
-        let std : f32 = outcome.get("std")?.try_into()?;
+        let std: f32 = outcome.get("std")?.try_into()?;
 
-        // Do some quick checks 
+        // Do some quick checks
         if max_lat <= min_lat {
-            return Err(ProcessError{error: format!("Max lat ({}) must be > than min lat ({})",max_lat,min_lat)});
+            return Err(ProcessError {
+                error: format!("Max lat ({}) must be > than min lat ({})", max_lat, min_lat),
+            });
         }
-        if max_lng <= min_lng{
-            return Err(ProcessError{error: format!("Max lng ({}) must be > than min lng ({})",max_lng,min_lng)});
+        if max_lng <= min_lng {
+            return Err(ProcessError {
+                error: format!("Max lng ({}) must be > than min lng ({})", max_lng, min_lng),
+            });
         }
 
         // Generate the random geometries
-        let mut rng = rand::thread_rng(); 
-        
-        let points :Vec<Geometry<f64>> = (0..no_points).map(|_| {
-            let y: f32 = rng.gen_range(min_lat..max_lat);
-            let x: f32 = rng.gen_range(min_lng..max_lng);
-            Geometry::Point(Point::<f64>::new(x as f64, y as f64))
-        }).collect();
+        let mut rng = rand::thread_rng();
+
+        let points: Vec<Geometry<f64>> = (0..no_points)
+            .map(|_| {
+                let y: f32 = rng.gen_range(min_lat..max_lat);
+                let x: f32 = rng.gen_range(min_lng..max_lng);
+                Geometry::Point(Point::<f64>::new(x as f64, y as f64))
+            })
+            .collect();
 
         web_sys::console::log_1(&"Generated points".into());
 
         // Construct the geoseries
 
-        let geo_series = Series::from_geom_vec(&points).
-            map_err(|e| ProcessError{
-                error: format!("Failed to construct geo series {:#?}",e)
-            })?;
+        let geo_series = Series::from_geom_vec(&points).map_err(|e| ProcessError {
+            error: format!("Failed to construct geo series {:#?}", e),
+        })?;
 
         // construct noise
 
-        let mut rng = rand::thread_rng(); 
-        
-        let points :Vec<Geometry<f64>> = (0..no_points).map(|_| {
-            let y: f32 = rng.gen_range(min_lat..max_lat);
-            let x: f32 = rng.gen_range(min_lng..max_lng);
-            Geometry::Point(Point::<f64>::new(x as f64, y as f64))
-        }).collect();
+        let mut rng = rand::thread_rng();
 
+        let points: Vec<Geometry<f64>> = (0..no_points)
+            .map(|_| {
+                let y: f32 = rng.gen_range(min_lat..max_lat);
+                let x: f32 = rng.gen_range(min_lng..max_lng);
+                Geometry::Point(Point::<f64>::new(x as f64, y as f64))
+            })
+            .collect();
 
         // Construct the distribution
-        
 
-        let variables : Vec<ParameterValue> = self.get_parameter("variables")?.try_into()?;  
+        let variables: Vec<ParameterValue> = self.get_parameter("variables")?.try_into()?;
         let mut result_series: Vec<Series> = vec![];
 
         // construct mean sample
-        let dist = Normal::new(intercept,std).map_err(|e| ProcessError{
-            error: format!("Failed to generate normal {:#?}",e)
+        let dist = Normal::new(intercept, std).map_err(|e| ProcessError {
+            error: format!("Failed to generate normal {:#?}", e),
         })?;
 
-        let mean: Vec<f32> = (0..no_points).map(|_| {
-            let v: f32=  dist.sample(&mut rng); 
-            v
-        }).collect();
+        let mean: Vec<f32> = (0..no_points)
+            .map(|_| {
+                let v: f32 = dist.sample(&mut rng);
+                v
+            })
+            .collect();
 
-        let mean : Series = Series::from_vec("fruit_mean", mean);
+        let mean: Series = Series::from_vec("fruit_mean", mean);
         result_series.push(mean);
 
-        let control_variable : Vec<u32> = (0..no_points).map(|_| {
-            let v: bool= rng.gen_bool(control_fraction as f64); 
-            if v {
-                return  1
-            }
-            else{
-                return 0
-            }
-        }).collect();
+        let control_variable: Vec<u32> = (0..no_points)
+            .map(|_| {
+                let v: bool = rng.gen_bool(control_fraction as f64);
+                if v {
+                    return 1;
+                } else {
+                    return 0;
+                }
+            })
+            .collect();
 
-
-        let control_variable : Series = Series::from_vec("control", control_variable);
+        let control_variable: Series = Series::from_vec("control", control_variable);
         result_series.push(control_variable);
 
         // Construct the distributions for each variable
-        for variable in variables.iter(){
+        for variable in variables.iter() {
+            let variable_params: OptionGroupVals = variable.try_into()?;
 
-            let variable_params : OptionGroupVals = variable.try_into()?;
-        
             let variable_name: String = variable_params.get("variable_name")?.try_into()?;
             let variable_lambda: f32 = variable_params.get("variable_lambda")?.try_into()?;
             let beta: f32 = variable_params.get("beta")?.try_into()?;
             let beta_control: f32 = variable_params.get("beta_control")?.try_into()?;
 
-            
-
-            let dist = Poisson::new(variable_lambda).map_err(|e| ProcessError{
-                error: format!("Failed to generate normal {:#?}",e)
+            let dist = Poisson::new(variable_lambda).map_err(|e| ProcessError {
+                error: format!("Failed to generate normal {:#?}", e),
             })?;
 
-            let variable : Vec<f32> = (0..no_points).map(|_| {
-                let v: f32= dist.sample(&mut rng); 
-                v
-            }).collect();
+            let variable: Vec<f32> = (0..no_points)
+                .map(|_| {
+                    let v: f32 = dist.sample(&mut rng);
+                    v
+                })
+                .collect();
 
             web_sys::console::log_1(&"Calculated distribution".into());
 
-            let variable : Series = Series::from_vec(&variable_name, variable);
+            let variable: Series = Series::from_vec(&variable_name, variable);
             result_series.push(variable);
         }
 
-
-
-
         result_series.push(geo_series);
-        // Generate the result 
-        let result = DataFrame::new(result_series).map_err(|e|
-            ProcessError{
-                error: format!("Failed to construct result df {}", e)
-            });
-
+        // Generate the result
+        let result = DataFrame::new(result_series).map_err(|e| ProcessError {
+            error: format!("Failed to construct result df {}", e),
+        });
 
         web_sys::console::log_1(&"Created result and returnign".into());
         result
     }
 
-    fn description()->Option<String>{
-        Some("Cluster the provided points in to clusters".into()) 
+    fn description() -> Option<String> {
+        Some("Cluster the provided points in to clusters".into())
     }
 
     fn options() -> BTreeMap<String, ParameterOptions> {
         let mut options: BTreeMap<String, ParameterOptions> = BTreeMap::new();
-        
+
         let mut region_options: BTreeMap<String, ParameterOptions> = BTreeMap::new();
-        region_options.insert("min_lat".into(), ParameterOptions::NumericFloat(NumericFloatOptions{
-            default: Some(20.),
-            range: None,
-            display_details:ParameterOptionDisplayDetails{
-                description:None,
-                display_name:Some("Min latitude to place points in".into())
-            }
-        }));
+        region_options.insert(
+            "min_lat".into(),
+            ParameterOptions::NumericFloat(NumericFloatOptions {
+                default: Some(20.),
+                range: None,
+                display_details: ParameterOptionDisplayDetails {
+                    description: None,
+                    display_name: Some("Min latitude to place points in".into()),
+                },
+            }),
+        );
 
-        region_options.insert("max_lat".into(), ParameterOptions::NumericFloat(NumericFloatOptions{
-            default: Some(20.),
-            range: None,
-            display_details:ParameterOptionDisplayDetails{
-                description:None,
-                display_name:Some("Max latitude to place points in".into())
-            }
-        }));
-        region_options.insert("min_lng".into(), ParameterOptions::NumericFloat(NumericFloatOptions{
-            default: Some(20.),
-            range: None,
-            display_details:ParameterOptionDisplayDetails{
-                description:None,
-                display_name:Some("Min longitude to place points in".into())
-            }
-        }));
-        region_options.insert("max_lng".into(), ParameterOptions::NumericFloat(NumericFloatOptions{
-            default: Some(20.),
-            range: None,
-            display_details:ParameterOptionDisplayDetails{
-                description:None,
-                display_name:Some("Max longitude to place points in".into())
-            }
-        }));
+        region_options.insert(
+            "max_lat".into(),
+            ParameterOptions::NumericFloat(NumericFloatOptions {
+                default: Some(20.),
+                range: None,
+                display_details: ParameterOptionDisplayDetails {
+                    description: None,
+                    display_name: Some("Max latitude to place points in".into()),
+                },
+            }),
+        );
+        region_options.insert(
+            "min_lng".into(),
+            ParameterOptions::NumericFloat(NumericFloatOptions {
+                default: Some(20.),
+                range: None,
+                display_details: ParameterOptionDisplayDetails {
+                    description: None,
+                    display_name: Some("Min longitude to place points in".into()),
+                },
+            }),
+        );
+        region_options.insert(
+            "max_lng".into(),
+            ParameterOptions::NumericFloat(NumericFloatOptions {
+                default: Some(20.),
+                range: None,
+                display_details: ParameterOptionDisplayDetails {
+                    description: None,
+                    display_name: Some("Max longitude to place points in".into()),
+                },
+            }),
+        );
 
-        let region_options = OptionGroup{
-           options: region_options,
-           display_details: ParameterOptionDisplayDetails { description: 
-               Some("Bounding box where you want your trees planted".into()), display_name: Some("Region".into()) }
-        }; 
-
+        let region_options = OptionGroup {
+            options: region_options,
+            display_details: ParameterOptionDisplayDetails {
+                description: Some("Bounding box where you want your trees planted".into()),
+                display_name: Some("Region".into()),
+            },
+        };
 
         let mut outcome_options: BTreeMap<String, ParameterOptions> = BTreeMap::new();
 
-        outcome_options.insert("no_points".into(), ParameterOptions::NumericInt(NumericIntOptions{
-            default: Some(20),
-            range: None,
-            display_details:ParameterOptionDisplayDetails{
-                description:Some("No of points to generate".into()),
-                display_name:Some("No points".into())
-            }
-        }));
+        outcome_options.insert(
+            "no_points".into(),
+            ParameterOptions::NumericInt(NumericIntOptions {
+                default: Some(20),
+                range: None,
+                display_details: ParameterOptionDisplayDetails {
+                    description: Some("No of points to generate".into()),
+                    display_name: Some("No points".into()),
+                },
+            }),
+        );
 
-        outcome_options.insert("control_fraction".into(), ParameterOptions::NumericFloat(NumericFloatOptions{
-            default: Some(0.3),
-            range:None,
-            display_details:ParameterOptionDisplayDetails{
-                description:Some("What fraction of the points should be in the control group".into()),
-                display_name: Some("Control Fraction".into())
-            }
-        }));
-        outcome_options.insert("intercept".into(), ParameterOptions::NumericFloat(NumericFloatOptions{
-            default: Some(20.),
-            range: None,
-            display_details:ParameterOptionDisplayDetails{
-                description:Some("Intercept of the observation variable".into()),
-                display_name:Some("Intercept".into())
-            }
-        }));
+        outcome_options.insert(
+            "control_fraction".into(),
+            ParameterOptions::NumericFloat(NumericFloatOptions {
+                default: Some(0.3),
+                range: None,
+                display_details: ParameterOptionDisplayDetails {
+                    description: Some(
+                        "What fraction of the points should be in the control group".into(),
+                    ),
+                    display_name: Some("Control Fraction".into()),
+                },
+            }),
+        );
+        outcome_options.insert(
+            "intercept".into(),
+            ParameterOptions::NumericFloat(NumericFloatOptions {
+                default: Some(20.),
+                range: None,
+                display_details: ParameterOptionDisplayDetails {
+                    description: Some("Intercept of the observation variable".into()),
+                    display_name: Some("Intercept".into()),
+                },
+            }),
+        );
 
-        outcome_options.insert("std".into(), ParameterOptions::NumericFloat(NumericFloatOptions{
-            default: Some(20.),
-            range: None,
-            display_details:ParameterOptionDisplayDetails{
-                description:Some("Outcome std".into()),
-                display_name:Some("Error term on the outcome ".into())
-            }
-        }));
+        outcome_options.insert(
+            "std".into(),
+            ParameterOptions::NumericFloat(NumericFloatOptions {
+                default: Some(20.),
+                range: None,
+                display_details: ParameterOptionDisplayDetails {
+                    description: Some("Outcome std".into()),
+                    display_name: Some("Error term on the outcome ".into()),
+                },
+            }),
+        );
 
-        let outcome_options = OptionGroup{
-           options: outcome_options,
-           display_details: ParameterOptionDisplayDetails { description: 
-               Some("Details about the outcome variable".into()), display_name: Some("Outcome".into()) }
-        }; 
-
-
-        let mut variable_options:BTreeMap<String,ParameterOptions> = BTreeMap::new();
-        variable_options.insert("variable_lambda".into(), ParameterOptions::NumericFloat(NumericFloatOptions{
-            default: Some(1.0),
-            range: Some([0.0,10000.0]),
-            display_details:ParameterOptionDisplayDetails{
-                description:Some("The lambda value of the poisson distribution of the variable".into()),
-                display_name:Some("Lambda".into())
-            }
-        }));
-
-        variable_options.insert("beta".into(), ParameterOptions::NumericFloat(NumericFloatOptions{
-            default: Some(1.0),
-            range: Some([0.0,10000.0]),
-            display_details:ParameterOptionDisplayDetails{
-                description:Some("The correlation coefficent of the variable when not in the control group ".into()),
-                display_name:Some("Beta".into())
-            }
-        }));
-
-        variable_options.insert("beta_control".into(), ParameterOptions::NumericFloat(NumericFloatOptions{
-            default: Some(1.0),
-            range: Some([-10000.0,10000.0]),
-            display_details:ParameterOptionDisplayDetails{
-                description:Some("The correlation coefficent of the variable when in the control group".into()),
-                display_name:Some("Beta control".into())
-            }
-        }));
-
-        variable_options.insert("variable_name".into(), ParameterOptions::Text(TextOptions{
-            default: Some("variable".into()),
-            display_details:ParameterOptionDisplayDetails{
-                description:Some("What to call the random variable".into()),
-                display_name:Some("Variable name".into())
+        let outcome_options = OptionGroup {
+            options: outcome_options,
+            display_details: ParameterOptionDisplayDetails {
+                description: Some("Details about the outcome variable".into()),
+                display_name: Some("Outcome".into()),
             },
-            ..Default::default()
-        })); 
-
-
-        let variable_options = RepeatedOption{
-        display_details: ParameterOptionDisplayDetails { description: Some("Variables to add to the resulting table".into()), display_name: Some("Variables".into()) },
-        min_times:0,
-        max_times: Some(10),
-
-        options: Box::new(ParameterOptions::OptionGroup(OptionGroup{
-            display_details: ParameterOptionDisplayDetails { description: Some("Details of a random variable to add to the dataset".into()), display_name: Some("Variable".into()) },
-            options : variable_options
-
-        }))
         };
-        options.insert("outcome".into(), ParameterOptions::OptionGroup(outcome_options));
-        options.insert("region".into(), ParameterOptions::OptionGroup(region_options));
-        options.insert("variables".into(), ParameterOptions::RepeatedOption(variable_options));
 
+        let mut variable_options: BTreeMap<String, ParameterOptions> = BTreeMap::new();
+        variable_options.insert(
+            "variable_lambda".into(),
+            ParameterOptions::NumericFloat(NumericFloatOptions {
+                default: Some(1.0),
+                range: Some([0.0, 10000.0]),
+                display_details: ParameterOptionDisplayDetails {
+                    description: Some(
+                        "The lambda value of the poisson distribution of the variable".into(),
+                    ),
+                    display_name: Some("Lambda".into()),
+                },
+            }),
+        );
 
+        variable_options.insert(
+            "beta".into(),
+            ParameterOptions::NumericFloat(NumericFloatOptions {
+                default: Some(1.0),
+                range: Some([0.0, 10000.0]),
+                display_details: ParameterOptionDisplayDetails {
+                    description: Some(
+                        "The correlation coefficent of the variable when not in the control group "
+                            .into(),
+                    ),
+                    display_name: Some("Beta".into()),
+                },
+            }),
+        );
+
+        variable_options.insert(
+            "beta_control".into(),
+            ParameterOptions::NumericFloat(NumericFloatOptions {
+                default: Some(1.0),
+                range: Some([-10000.0, 10000.0]),
+                display_details: ParameterOptionDisplayDetails {
+                    description: Some(
+                        "The correlation coefficent of the variable when in the control group"
+                            .into(),
+                    ),
+                    display_name: Some("Beta control".into()),
+                },
+            }),
+        );
+
+        variable_options.insert(
+            "variable_name".into(),
+            ParameterOptions::Text(TextOptions {
+                default: Some("variable".into()),
+                display_details: ParameterOptionDisplayDetails {
+                    description: Some("What to call the random variable".into()),
+                    display_name: Some("Variable name".into()),
+                },
+                ..Default::default()
+            }),
+        );
+
+        let variable_options = RepeatedOption {
+            display_details: ParameterOptionDisplayDetails {
+                description: Some("Variables to add to the resulting table".into()),
+                display_name: Some("Variables".into()),
+            },
+            min_times: 0,
+            max_times: Some(10),
+
+            options: Box::new(ParameterOptions::OptionGroup(OptionGroup {
+                display_details: ParameterOptionDisplayDetails {
+                    description: Some("Details of a random variable to add to the dataset".into()),
+                    display_name: Some("Variable".into()),
+                },
+                options: variable_options,
+            })),
+        };
+        options.insert(
+            "outcome".into(),
+            ParameterOptions::OptionGroup(outcome_options),
+        );
+        options.insert(
+            "region".into(),
+            ParameterOptions::OptionGroup(region_options),
+        );
+        options.insert(
+            "variables".into(),
+            ParameterOptions::RepeatedOption(variable_options),
+        );
 
         options
-
     }
 }
 
 #[cfg(test)]
-mod tests {
-
-}
+mod tests {}

--- a/matico_server/src/db/query_builder.rs
+++ b/matico_server/src/db/query_builder.rs
@@ -54,9 +54,13 @@ pub trait QueryBuilder<T> {
     /// something more generic depending on how other interfaces use this system
     fn base_query(&self) -> Result<String, crate::errors::ServiceError>;
 
-
     /// Updates the given feature
-    async fn update_feature(db: &T, dataset: Dataset, feature_id: String, update: serde_json::Value)->Result<BTreeMap<String, Option<QueryVal>>,crate::errors::ServiceError>;
+    async fn update_feature(
+        db: &T,
+        dataset: Dataset,
+        feature_id: String,
+        update: serde_json::Value,
+    ) -> Result<BTreeMap<String, Option<QueryVal>>, crate::errors::ServiceError>;
 
     /// Builds the final query taking in to account the base query, the base query, user, filters,
     /// bounds, sort, pagination and tileID

--- a/matico_server/src/errors.rs
+++ b/matico_server/src/errors.rs
@@ -2,12 +2,12 @@ use actix_web::{error::ResponseError, HttpResponse};
 use derive_more::Display;
 use serde::Serialize;
 
-#[derive(Debug,Serialize)]
-pub struct QueryFailDetails{
+#[derive(Debug, Serialize)]
+pub struct QueryFailDetails {
     pub error: String,
     pub query: Option<String>,
-    pub full_query: Option<String>
-} 
+    pub full_query: Option<String>,
+}
 
 #[derive(Debug, Display)]
 pub enum ServiceError {
@@ -80,9 +80,7 @@ impl ResponseError for ServiceError {
             ServiceError::APIFailed(reason) => {
                 HttpResponse::BadRequest().json(format!("API failed {}", reason))
             }
-            ServiceError::QueryFailed(reason) => {
-                HttpResponse::InternalServerError().json(reason)
-            }
+            ServiceError::QueryFailed(reason) => HttpResponse::InternalServerError().json(reason),
             ServiceError::DBConfigError(reason) => {
                 HttpResponse::InternalServerError().json(format!("Invalid DB Config {}", reason))
             }

--- a/matico_server/src/models/columns.rs
+++ b/matico_server/src/models/columns.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 #[derive(Serialize, Deserialize, Clone, Debug, TS)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct Column {
     pub name: String,

--- a/matico_server/src/models/stats.rs
+++ b/matico_server/src/models/stats.rs
@@ -6,7 +6,7 @@ use ts_rs::TS;
 
 // Input structures
 #[derive(Serialize, Deserialize, Debug, TS)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct EqualIntervalParams {
     pub no_bins: usize,
@@ -14,7 +14,7 @@ pub struct EqualIntervalParams {
 }
 
 #[derive(Serialize, Deserialize, Debug, TS)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct LogorithmicParams {
     pub no_bins: usize,
@@ -23,7 +23,7 @@ pub struct LogorithmicParams {
 }
 
 #[derive(Serialize, Deserialize, Debug, TS)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct JenksParams {
     pub no_bins: usize,
@@ -31,7 +31,7 @@ pub struct JenksParams {
 }
 
 #[derive(Serialize, Deserialize, Debug, TS)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct QuantileParams {
     pub no_bins: usize,
@@ -39,14 +39,14 @@ pub struct QuantileParams {
 }
 
 #[derive(Serialize, Deserialize, Debug, TS)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct BasicStatsParams {
     pub treat_null_as_zero: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, TS)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct HistogramParams {
     pub treat_null_as_zero: Option<bool>,
@@ -56,14 +56,14 @@ pub struct HistogramParams {
 }
 
 #[derive(Serialize, Deserialize, Debug, TS)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct ValueCountsParams {
     pub ignore_null: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, TS)]
-#[serde(rename_all="camelCase", tag="type")]
+#[serde(rename_all = "camelCase", tag = "type")]
 #[ts(export)]
 pub enum StatParams {
     Quantiles(QuantileParams),
@@ -77,7 +77,7 @@ pub enum StatParams {
 // Output types for returning results
 
 #[derive(Serialize, Deserialize, Debug, TS, FromRow)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct QuantileEntry {
     pub quantile: i32,
@@ -90,17 +90,17 @@ pub struct QuantileEntry {
 pub struct QuantileResults(pub Vec<QuantileEntry>);
 
 #[derive(Serialize, Deserialize, Debug, TS, FromRow)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct JenksEntry {
     pub bin_start: f64,
     pub bin_end: f64,
-    pub freq: i64
+    pub freq: i64,
 }
 
 #[derive(Serialize, Deserialize, Debug, TS)]
 #[ts(export)]
-pub struct JenksResults(pub Vec<JenksEntry>); 
+pub struct JenksResults(pub Vec<JenksEntry>);
 
 #[derive(Serialize, Deserialize, Debug, TS)]
 #[ts(export)]
@@ -111,7 +111,7 @@ pub struct LogorithmicResults {
 }
 
 #[derive(Serialize, Deserialize, Debug, TS, FromRow)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct BasicStatsResults {
     pub min: f64,
@@ -123,7 +123,7 @@ pub struct BasicStatsResults {
 }
 
 #[derive(Serialize, Deserialize, Debug, TS, FromRow)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct ValueCountEntry {
     count: i32,
@@ -131,7 +131,7 @@ pub struct ValueCountEntry {
 }
 
 #[derive(Serialize, Deserialize, Debug, TS, FromRow)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct HistogramEntry {
     bin_start: f64,
@@ -149,7 +149,7 @@ pub struct HistogramResults(pub Vec<HistogramEntry>);
 pub struct ValueCountsResults(pub Vec<ValueCountEntry>);
 
 #[derive(Serialize, Deserialize, Debug, TS)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub enum StatResults {
     Quantiles(QuantileResults),

--- a/matico_server/src/utils/geo_file_utils.rs
+++ b/matico_server/src/utils/geo_file_utils.rs
@@ -234,4 +234,3 @@ pub async fn load_csv_dataset_to_db(
     println!("Uploaded geo file {:?} ", output);
     Ok(())
 }
-

--- a/matico_server/tests/helpers/mod.rs
+++ b/matico_server/tests/helpers/mod.rs
@@ -13,11 +13,11 @@ pub type DbPool = r2d2::Pool<diesel::r2d2::ConnectionManager<diesel::pg::PgConne
 pub type DataDbPool = sqlx::PgPool;
 
 pub mod imports;
-pub mod users;
 pub mod stats;
+pub mod users;
 pub use imports::*;
-pub use users::*;
 pub use stats::*;
+pub use users::*;
 
 use once_cell::sync::Lazy;
 

--- a/matico_server/tests/helpers/stats.rs
+++ b/matico_server/tests/helpers/stats.rs
@@ -5,16 +5,18 @@ pub async fn get_stat(
     column_name: &str,
     url: &str,
     stat_parameters: &str,
-    token: Option<&str>
+    token: Option<&str>,
 ) -> Result<reqwest::Response, reqwest::Error> {
     let client = reqwest::Client::new();
 
-    let api_url = format!("{url}/{source_type}/{source_id}/columns/{column_name}/stats", 
+    let api_url = format!(
+        "{url}/{source_type}/{source_id}/columns/{column_name}/stats",
         source_type = "dataset",
         source_id = dataset_id,
-        url=url,
-        column_name = column_name);
-    
+        url = url,
+        column_name = column_name
+    );
+
     let mut request = client.get(api_url).query(&[("stat", stat_parameters)]);
 
     // let stat_params: String = serde_json::to_string(stat_parameters);

--- a/matico_server/tests/stats.rs
+++ b/matico_server/tests/stats.rs
@@ -1,40 +1,40 @@
 mod helpers;
 use actix::fut::future::result;
-use helpers::{spawn_app, signup_user, upload_file, get_stat};
+use helpers::{get_stat, signup_user, spawn_app, upload_file};
 
 use reqwest::StatusCode;
 use serde::Deserialize;
 use serde::Serialize;
-use serde_json::Value;
 use serde_json::json;
+use serde_json::Value;
 
 use matico_server::models::stats::JenksEntry;
 
-#[derive(Deserialize,Debug)]
-struct QueryError{
-    pub query:Option<String>,
-    pub full_query:Option<String>,
-    pub error:String
+#[derive(Deserialize, Debug)]
+struct QueryError {
+    pub query: Option<String>,
+    pub full_query: Option<String>,
+    pub error: String,
 }
 
 #[derive(Deserialize)]
-struct JenksResult{
-  jenks: Vec<JenksEntry>
+struct JenksResult {
+    jenks: Vec<JenksEntry>,
 }
 
 #[actix_web::test]
-async fn test_jenks_stat_on_dataset() { 
-    let test_server = spawn_app().await; 
-    let url = test_server.url("/datasets"); 
-    let user = signup_user( 
-        "test.test@test.com", 
-        "test", 
-        "passwword", 
-        &test_server.address, 
-    ) 
-    .await 
-    .expect("Failed to create user"); 
- 
+async fn test_jenks_stat_on_dataset() {
+    let test_server = spawn_app().await;
+    let url = test_server.url("/datasets");
+    let user = signup_user(
+        "test.test@test.com",
+        "test",
+        "passwword",
+        &test_server.address,
+    )
+    .await
+    .expect("Failed to create user");
+
     let metadata = json!({
         "name": "test dataset",
         "description":"Some dataset that we are testing with",
@@ -46,13 +46,13 @@ async fn test_jenks_stat_on_dataset() {
         }
     });
 
-    let file_upload_result = upload_file( 
-        "resources/test/geojson_data.geojson", 
-        &url, 
-        metadata.to_string(), 
-        Some(&user.token), 
-    ) 
-    .await 
+    let file_upload_result = upload_file(
+        "resources/test/geojson_data.geojson",
+        &url,
+        metadata.to_string(),
+        Some(&user.token),
+    )
+    .await
     .unwrap();
 
     let dataset_body: Value = file_upload_result.json().await.unwrap();
@@ -61,16 +61,17 @@ async fn test_jenks_stat_on_dataset() {
         "type":"jenks",
         "noBins":5_i32
     });
-    
-    let result = get_stat(
-        dataset_body["id"].as_str().unwrap(), 
-        "numbers", 
-        &test_server.url("/data"), 
-        &stat_params.to_string(), 
-        Some(&user.token)
-        ).await;
 
-    assert!(result.is_ok() ,  "Query should not fail");
+    let result = get_stat(
+        dataset_body["id"].as_str().unwrap(),
+        "numbers",
+        &test_server.url("/data"),
+        &stat_params.to_string(),
+        Some(&user.token),
+    )
+    .await;
+
+    assert!(result.is_ok(), "Query should not fail");
     let result = result.unwrap();
 
     // // Debugging
@@ -89,13 +90,20 @@ async fn test_jenks_stat_on_dataset() {
 
     let result: JenksResult = result.json().await.unwrap();
     let bins: Vec<JenksEntry> = result.jenks;
-   
+
     // Test if number of bins is correct
-    assert_eq!(stat_params["noBins"], bins.len(), "Wrong number of bins in output");
+    assert_eq!(
+        stat_params["noBins"],
+        bins.len(),
+        "Wrong number of bins in output"
+    );
 
     // Test if bin bounds match
-    for i in 0 .. stat_params["noBins"].as_u64().unwrap() - 1 {
-        assert!(bins[i as usize].bin_end == bins[(i + 1) as usize].bin_start, "Bin bounds don't match");
+    for i in 0..stat_params["noBins"].as_u64().unwrap() - 1 {
+        assert!(
+            bins[i as usize].bin_end == bins[(i + 1) as usize].bin_start,
+            "Bin bounds don't match"
+        );
     }
 
     // Test if total number of data points is correct
@@ -104,5 +112,4 @@ async fn test_jenks_stat_on_dataset() {
         count += bin.freq as usize;
     }
     assert!(count == 20, "Number of data points is incorrect");
-
 }

--- a/matico_spec/src/apps.rs
+++ b/matico_spec/src/apps.rs
@@ -1,4 +1,4 @@
-use crate::{AutoComplete, Dataset, Page, Pane, Theme, ValidationResult, DatasetTransform};
+use crate::{AutoComplete, Dataset, DatasetTransform, Page, Pane, Theme, ValidationResult};
 use chrono::{DateTime, Utc};
 use matico_spec_derive::AutoCompleteMe;
 use serde::{Deserialize, Serialize};

--- a/matico_spec/src/charts.rs
+++ b/matico_spec/src/charts.rs
@@ -128,7 +128,6 @@ impl LineChartPane {
     }
 }
 
-
 #[wasm_bindgen]
 #[derive(Default, Serialize, Deserialize, Validate, Debug, Clone, AutoCompleteMe, TS)]
 #[serde(rename_all = "camelCase")]

--- a/matico_spec/src/controls.rs
+++ b/matico_spec/src/controls.rs
@@ -1,4 +1,4 @@
-use crate::{VarOr, DatasetRef,AutoComplete,MappingVarOr};
+use crate::{AutoComplete, DatasetRef, MappingVarOr, VarOr};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
@@ -20,7 +20,7 @@ pub enum Control {
 pub struct SelectControl {
     name: String,
     options: VarOr<Vec<String>>,
-    default_value: Option<String>
+    default_value: Option<String>,
 }
 
 #[wasm_bindgen]
@@ -35,12 +35,11 @@ pub struct RangeControl {
     default_value: f32,
 }
 
-
 #[wasm_bindgen]
-#[derive(Serialize, Deserialize,Debug,Clone,Validate,TS)]
-#[serde(rename_all="camelCase")]
+#[derive(Serialize, Deserialize, Debug, Clone, Validate, TS)]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct DateTimeSliderPane{
+pub struct DateTimeSliderPane {
     #[wasm_bindgen(skip)]
     pub column: String,
     #[wasm_bindgen(skip)]
@@ -55,6 +54,4 @@ pub struct DateTimeSliderPane{
     pub min: VarOr<DateTime<Utc>>,
     #[wasm_bindgen(skip)]
     pub name: String,
-    
 }
-

--- a/matico_spec/src/dataset_transforms.rs
+++ b/matico_spec/src/dataset_transforms.rs
@@ -1,27 +1,24 @@
-use crate::{
-    AutoComplete,Filter, WASMCompute
-};
+use crate::{AutoComplete, Filter, WASMCompute};
 use matico_spec_derive::AutoCompleteMe;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 use validator::Validate;
 use wasm_bindgen::prelude::*;
 
-
-#[derive(Serialize, Deserialize,  AutoCompleteMe, Debug, TS)]
+#[derive(Serialize, Deserialize, AutoCompleteMe, Debug, TS)]
 #[serde(rename_all = "camelCase", tag = "type")]
 #[ts(export)]
-pub enum DatasetTransformStep{
-   Filter(FilterStep),
-   Aggregate(AggregateStep),
-   Join(JoinStep),
-   Compute(WASMCompute),
-   ColumnTransformStep(ColumnTransformStep)
-} 
+pub enum DatasetTransformStep {
+    Filter(FilterStep),
+    Aggregate(AggregateStep),
+    Join(JoinStep),
+    Compute(WASMCompute),
+    ColumnTransformStep(ColumnTransformStep),
+}
 
-impl Default for DatasetTransformStep{
-    fn default()->Self{
-        DatasetTransformStep::Filter(FilterStep{filters:vec![]})
+impl Default for DatasetTransformStep {
+    fn default() -> Self {
+        DatasetTransformStep::Filter(FilterStep { filters: vec![] })
     }
 }
 
@@ -29,15 +26,15 @@ impl Default for DatasetTransformStep{
 #[derive(Serialize, Deserialize, AutoCompleteMe, Debug, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub enum JoinType{
+pub enum JoinType {
     Inner,
     Outer,
     Left,
-    Right
+    Right,
 }
 
-impl Default for JoinType{
-    fn default()->Self{
+impl Default for JoinType {
+    fn default() -> Self {
         JoinType::Inner
     }
 }
@@ -46,20 +43,20 @@ impl Default for JoinType{
 #[derive(Serialize, Deserialize, Validate, AutoCompleteMe, Default, Debug, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct AggregateStep{
+pub struct AggregateStep {
     #[wasm_bindgen(skip)]
     pub group_by_columns: Vec<String>,
     #[wasm_bindgen(skip)]
-    pub aggregate:Vec<AggregationSummary>
+    pub aggregate: Vec<AggregationSummary>,
 }
 
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize, Validate, AutoCompleteMe, Default, Debug, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct FilterStep{
+pub struct FilterStep {
     #[wasm_bindgen(skip)]
-    pub filters:Vec<Filter>
+    pub filters: Vec<Filter>,
 }
 
 // #[wasm_bindgen]
@@ -87,108 +84,100 @@ pub struct FilterStep{
 // }
 
 #[derive(Serialize, Deserialize, AutoCompleteMe, Debug, TS)]
-#[serde(rename_all = "camelCase", tag="type")]
+#[serde(rename_all = "camelCase", tag = "type")]
 #[ts(export)]
-pub struct DateOpts{
-    format: Option<String>
+pub struct DateOpts {
+    format: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, AutoCompleteMe, Debug, TS)]
-#[serde(rename_all = "camelCase", tag="type")]
+#[serde(rename_all = "camelCase", tag = "type")]
 #[ts(export)]
-pub struct StringOpts{
-    template: Option<String>
+pub struct StringOpts {
+    template: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, AutoCompleteMe, Debug, TS)]
-#[serde(rename_all = "camelCase", tag="type")]
+#[serde(rename_all = "camelCase", tag = "type")]
 #[ts(export)]
-pub struct IntOpts{
-    pub null_val: Option<i32>
+pub struct IntOpts {
+    pub null_val: Option<i32>,
 }
 
 #[derive(Serialize, Deserialize, AutoCompleteMe, Debug, TS)]
-#[serde(rename_all = "camelCase", tag="type")]
+#[serde(rename_all = "camelCase", tag = "type")]
 #[ts(export)]
-pub struct FloatOpts{
-    pub null_val: Option<i32>
+pub struct FloatOpts {
+    pub null_val: Option<i32>,
 }
-impl Default for DateOpts{
+impl Default for DateOpts {
     fn default() -> Self {
-       DateOpts{
-          format:Some("YYYY-MM-DD".into()) 
-        } 
-    }
-}
-impl Default for StringOpts{
-    fn default() -> Self {
-       StringOpts{
-          template:None 
-        } 
-    }
-}
-
-impl Default for IntOpts{
-    fn default() -> Self {
-        IntOpts{
-            null_val:None
+        DateOpts {
+            format: Some("YYYY-MM-DD".into()),
         }
     }
 }
-
-impl Default for FloatOpts{
+impl Default for StringOpts {
     fn default() -> Self {
-        FloatOpts{
-            null_val:None
-        }
+        StringOpts { template: None }
     }
 }
 
+impl Default for IntOpts {
+    fn default() -> Self {
+        IntOpts { null_val: None }
+    }
+}
+
+impl Default for FloatOpts {
+    fn default() -> Self {
+        FloatOpts { null_val: None }
+    }
+}
 
 #[derive(Serialize, Deserialize, AutoCompleteMe, Debug, TS)]
-#[serde(rename_all = "camelCase", tag="type")]
+#[serde(rename_all = "camelCase", tag = "type")]
 #[ts(export)]
-pub enum ChangeType{
+pub enum ChangeType {
     Date(DateOpts),
     String(StringOpts),
     Int(IntOpts),
-    Float(FloatOpts)
+    Float(FloatOpts),
 }
 
-impl Default for ChangeType{
+impl Default for ChangeType {
     fn default() -> Self {
         ChangeType::Int(IntOpts::default())
     }
 }
 
-
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize, Validate, AutoCompleteMe, Default, Debug, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct ColumnTransform{
+pub struct ColumnTransform {
     #[wasm_bindgen(skip)]
     pub column: String,
     #[wasm_bindgen(skip)]
-    pub to: ChangeType 
+    pub to: ChangeType,
 }
 
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize, Validate, AutoCompleteMe, Default, Debug, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct ColumnTransformStep{
+pub struct ColumnTransformStep {
     #[wasm_bindgen(skip)]
-    pub transforms: Vec<ColumnTransform>
+    pub transforms: Vec<ColumnTransform>,
 }
 
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize, Validate, AutoCompleteMe, Default, Debug, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct JoinStep{
+pub struct JoinStep {
     #[wasm_bindgen(skip)]
-    pub other_source_id : String,
+    pub other_source_id: String,
     #[wasm_bindgen(skip)]
     pub join_type: JoinType,
     #[wasm_bindgen(skip)]
@@ -202,43 +191,40 @@ pub struct JoinStep{
 
     #[wasm_bindgen(skip)]
     pub right_prefix: String,
-
 }
-
 
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize, AutoCompleteMe, Debug, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub enum AggregationType{
+pub enum AggregationType {
     Min,
     Max,
     Sum,
     CumulativeSum,
     Mean,
     Median,
-    StandardDeviation
+    StandardDeviation,
 }
 
-impl Default for AggregationType{
+impl Default for AggregationType {
     fn default() -> Self {
-        return AggregationType::Mean
+        return AggregationType::Mean;
     }
 }
-
 
 #[derive(Serialize, Deserialize, AutoCompleteMe, Debug, TS)]
-#[serde(rename_all = "camelCase", tag="type", content="value")]
+#[serde(rename_all = "camelCase", tag = "type", content = "value")]
 #[ts(export)]
-pub enum ImputeMethod{
+pub enum ImputeMethod {
     Value(f32),
     Mean,
-    Median
+    Median,
 }
 
-impl Default for ImputeMethod{
-    fn default()->Self{
-        return ImputeMethod::Mean
+impl Default for ImputeMethod {
+    fn default() -> Self {
+        return ImputeMethod::Mean;
     }
 }
 
@@ -246,39 +232,37 @@ impl Default for ImputeMethod{
 #[derive(Serialize, Deserialize, Validate, AutoCompleteMe, Debug, Default, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct ImputeStep{
+pub struct ImputeStep {
     column: String,
-    method: ImputeMethod 
+    method: ImputeMethod,
 }
-
 
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize, Validate, AutoCompleteMe, Debug, Default, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct AggregationSummary{
+pub struct AggregationSummary {
     #[wasm_bindgen(skip)]
     pub column: String,
     #[wasm_bindgen(skip)]
     pub agg_type: AggregationType,
     #[wasm_bindgen(skip)]
-    pub rename: Option<String>
+    pub rename: Option<String>,
 }
-
 
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize, Validate, AutoCompleteMe, Debug, Default, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct DatasetTransform{
+pub struct DatasetTransform {
     #[wasm_bindgen(skip)]
     pub id: String,
     #[wasm_bindgen(skip)]
-    pub name:String,
+    pub name: String,
     #[wasm_bindgen(skip)]
     pub description: String,
     #[wasm_bindgen(skip)]
     pub source_id: String,
     #[wasm_bindgen(skip)]
-    pub steps: Vec<DatasetTransformStep>
+    pub steps: Vec<DatasetTransformStep>,
 }

--- a/matico_spec/src/datasets.rs
+++ b/matico_spec/src/datasets.rs
@@ -8,18 +8,18 @@ use wasm_bindgen::prelude::*;
 #[ts(export)]
 pub enum Dataset {
     GeoJSON(GeoJSONDataset),
-    #[serde(rename="csv")]
+    #[serde(rename = "csv")]
     CSV(CSVDataset),
     MaticoRemote(MaticoRemoteDataset),
     MaticoApi(MaticoApiDataset),
-    #[serde(rename="cog")]
+    #[serde(rename = "cog")]
     COG(COGDataset),
-    #[serde(rename="wasmCompute")]
+    #[serde(rename = "wasmCompute")]
     WASMCompute(WASMCompute),
-    #[serde(rename="arrow")]
+    #[serde(rename = "arrow")]
     Arrow(ArrowDataset),
-    #[serde(rename="signedS3Arrow")]
-    SignedS3Arrow(SignedS3ArrowDataset)
+    #[serde(rename = "signedS3Arrow")]
+    SignedS3Arrow(SignedS3ArrowDataset),
 }
 
 #[wasm_bindgen]
@@ -63,7 +63,6 @@ pub struct ArrowDataset {
     pub id_col: Option<String>,
 }
 
-
 #[wasm_bindgen]
 #[derive(Default, Serialize, Deserialize, Clone, Debug, TS)]
 #[serde(rename_all = "camelCase")]
@@ -81,7 +80,6 @@ pub struct SignedS3ArrowDataset {
     #[wasm_bindgen(skip)]
     pub id_col: Option<String>,
 }
-
 
 #[wasm_bindgen]
 #[derive(Default, Serialize, Deserialize, Clone, Debug, TS)]

--- a/matico_spec/src/layouts.rs
+++ b/matico_spec/src/layouts.rs
@@ -14,7 +14,9 @@ pub enum Layout {
 
 impl Default for Layout {
     fn default() -> Self {
-        Layout::Free(FreeLayout{allow_overflow:false})
+        Layout::Free(FreeLayout {
+            allow_overflow: false,
+        })
     }
 }
 
@@ -30,43 +32,42 @@ pub enum LinearLayoutDirection {
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize, Clone, Debug, TS, Copy)]
 #[ts(export)]
-pub enum Justification{
-    #[serde(rename="start")]
+pub enum Justification {
+    #[serde(rename = "start")]
     FlexStart,
-    #[serde(rename="end")]
+    #[serde(rename = "end")]
     FlexEnd,
-    #[serde(rename="center")]
+    #[serde(rename = "center")]
     Center,
-    #[serde(rename="space-between")]
+    #[serde(rename = "space-between")]
     SpaceBetween,
-    #[serde(rename="space-around")]
+    #[serde(rename = "space-around")]
     SpaceAround,
-    #[serde(rename="space-evenly")]
-    SpaceEvenly
+    #[serde(rename = "space-evenly")]
+    SpaceEvenly,
 }
 
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize, Clone, Debug, TS, Copy)]
 #[ts(export)]
-pub enum Alignment{
-    #[serde(rename="start")]
+pub enum Alignment {
+    #[serde(rename = "start")]
     FlexStart,
-    #[serde(rename="end")]
+    #[serde(rename = "end")]
     FlexEnd,
-    #[serde(rename="center")]
+    #[serde(rename = "center")]
     Center,
-    #[serde(rename="stretch")]
+    #[serde(rename = "stretch")]
     Stretch,
-    #[serde(rename="baseline")]
+    #[serde(rename = "baseline")]
     BaseLine,
 }
 
-
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize, Clone, Debug, TS, Copy)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub enum GapSize{
+pub enum GapSize {
     None,
     Small,
     Medium,
@@ -82,33 +83,31 @@ pub struct LinearLayout {
     pub allow_overflow: bool,
     pub justify: Justification,
     pub gap: Option<GapSize>,
-    pub align: Alignment
+    pub align: Alignment,
 }
-
 
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize, Clone, Debug, TS, Copy)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub enum TabBarPosition{
+pub enum TabBarPosition {
     Horizontal,
-    Vertical
-}
-
-
-#[wasm_bindgen]
-#[derive(Serialize, Deserialize, Clone, Debug, TS)]
-#[serde(rename_all = "camelCase")]
-#[ts(export)]
-pub struct TabLayout{
-    tab_bar_position: TabBarPosition
+    Vertical,
 }
 
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize, Clone, Debug, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct FreeLayout{
+pub struct TabLayout {
+    tab_bar_position: TabBarPosition,
+}
+
+#[wasm_bindgen]
+#[derive(Serialize, Deserialize, Clone, Debug, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub struct FreeLayout {
     pub allow_overflow: bool,
 }
 
@@ -120,4 +119,3 @@ pub struct GridLayout {
     rows: usize,
     cols: usize,
 }
-

--- a/matico_spec/src/lib.rs
+++ b/matico_spec/src/lib.rs
@@ -3,6 +3,7 @@ mod autocomplete;
 mod charts;
 mod colors;
 mod controls;
+mod dataset_transforms;
 mod datasets;
 mod layouts;
 mod mapping;
@@ -10,13 +11,13 @@ mod page;
 mod pane;
 mod theme;
 mod validation;
-mod dataset_transforms;
 
 pub use apps::*;
 pub use autocomplete::*;
 pub use charts::*;
 pub use colors::*;
 pub use controls::*;
+pub use dataset_transforms::*;
 pub use datasets::*;
 pub use layouts::*;
 pub use mapping::*;
@@ -25,7 +26,6 @@ pub use page::*;
 pub use pane::*;
 pub use theme::*;
 pub use validation::*;
-pub use dataset_transforms::*;
 
 #[macro_use]
 extern crate matico_spec_derive;

--- a/matico_spec/src/mapping.rs
+++ b/matico_spec/src/mapping.rs
@@ -1,6 +1,4 @@
-use crate::{
-    AutoComplete, ColorSpecification, Filter, MappingVarOr, VarOr, Labels,
-};
+use crate::{AutoComplete, ColorSpecification, Filter, Labels, MappingVarOr, VarOr};
 use matico_spec_derive::AutoCompleteMe;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
@@ -90,9 +88,7 @@ pub struct LayerStyle {
     elevation: Option<MappingVarOr<f32>>,
     elevation_scale: Option<f32>,
     before_id: Option<String>,
-    
 }
-
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Validate, AutoCompleteMe, TS)]
 #[serde(rename_all = "camelCase")]
@@ -100,9 +96,8 @@ pub struct LayerStyle {
 pub struct TooltipColumnSpec {
     column: String,
     label: String,
-    formatter: Option<String>
+    formatter: Option<String>,
 }
-
 
 #[derive(Serialize, Clone, Deserialize, Validate, Debug, Default, AutoCompleteMe, TS)]
 #[serde(rename_all = "camelCase")]
@@ -199,7 +194,7 @@ impl Default for SelectionMode {
 #[derive(Serialize, Clone, Deserialize, Debug, AutoCompleteMe, TS, Copy)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub enum MapProjection{
+pub enum MapProjection {
     GeoConicConformal,
     GeoTransverseMercator,
     GeoNaturalEarth1,
@@ -207,15 +202,14 @@ pub enum MapProjection{
     GeoOrthographic,
     GeoStereographic,
     GeoMercator,
-    GeoEquirectangular
+    GeoEquirectangular,
 }
 
-impl Default for MapProjection{
-    fn default()->Self{
+impl Default for MapProjection {
+    fn default() -> Self {
         MapProjection::GeoConicConformal
     }
 }
-
 
 #[wasm_bindgen]
 #[derive(Serialize, Clone, Deserialize, Validate, Debug, AutoCompleteMe, TS, Default, Copy)]
@@ -230,7 +224,7 @@ pub struct SelectionOptions {
 #[derive(Default, Serialize, Deserialize, Validate, Debug, Clone, AutoCompleteMe, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
-pub struct StaticMapPane{
+pub struct StaticMapPane {
     #[wasm_bindgen(skip)]
     pub labels: Option<Labels>,
 
@@ -242,7 +236,7 @@ pub struct StaticMapPane{
 
     #[wasm_bindgen(skip)]
     pub layers: Vec<Layer>,
-    
+
     #[wasm_bindgen(skip)]
     pub projection: Option<MapProjection>,
 
@@ -250,10 +244,8 @@ pub struct StaticMapPane{
     pub show_graticule: Option<bool>,
 
     #[wasm_bindgen(skip)]
-    pub rotation: Option<f32>
-
+    pub rotation: Option<f32>,
 }
-
 
 #[wasm_bindgen]
 #[derive(Serialize, Clone, Deserialize, Validate, Debug, AutoCompleteMe, TS)]

--- a/matico_spec/src/pane.rs
+++ b/matico_spec/src/pane.rs
@@ -1,13 +1,16 @@
-use crate::{AutoComplete, Control, HistogramPane, Layout, MapPane, PieChartPane, ScatterplotPane, StaticMapPane, DateTimeSliderPane};
+use crate::{
+    AutoComplete, Control, DateTimeSliderPane, HistogramPane, Layout, MapPane, PieChartPane,
+    ScatterplotPane, StaticMapPane,
+};
 use matico_spec_derive::AutoCompleteMe;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
+use uuid::Uuid;
 use validator::{Validate, ValidationErrors};
 use wasm_bindgen::prelude::*;
-use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize, Clone, TS)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct PaneDetails {
     pub id: String,
@@ -15,12 +18,12 @@ pub struct PaneDetails {
     pub position: PanePosition,
 }
 
-impl Default for PaneDetails{
-    fn default()->Self{
-        Self{
-            id:Uuid::new_v4().to_string(),
-            pane_id:"".into(),
-            position: Default::default()
+impl Default for PaneDetails {
+    fn default() -> Self {
+        Self {
+            id: Uuid::new_v4().to_string(),
+            pane_id: "".into(),
+            position: Default::default(),
         }
     }
 }
@@ -37,7 +40,7 @@ pub enum PaneRef {
     PieChart(PaneDetails),
     Controls(PaneDetails),
     StaticMap(PaneDetails),
-    DateTimeSlider(PaneDetails)
+    DateTimeSlider(PaneDetails),
 }
 
 impl PaneRef {
@@ -90,7 +93,7 @@ impl TryFrom<(&str, &str)> for PaneRef {
                 pane_id,
                 ..Default::default()
             })),
-            "dateTimeSlider" => Ok(PaneRef::DateTimeSlider(PaneDetails{
+            "dateTimeSlider" => Ok(PaneRef::DateTimeSlider(PaneDetails {
                 pane_id,
                 ..Default::default()
             })),
@@ -157,7 +160,7 @@ pub enum Pane {
     Scatterplot(ScatterplotPane),
     PieChart(PieChartPane),
     Controls(ControlsPane),
-    DateTimeSlider(DateTimeSliderPane)
+    DateTimeSlider(DateTimeSliderPane),
 }
 
 impl Default for Pane {
@@ -177,7 +180,9 @@ impl Validate for Pane {
         };
         match self {
             Self::Map(map) => ValidationErrors::merge(result, "MapPane", map.validate()),
-            Self::StaticMap(map) => ValidationErrors::merge(result, "StaticMapPane", map.validate()),
+            Self::StaticMap(map) => {
+                ValidationErrors::merge(result, "StaticMapPane", map.validate())
+            }
             Self::Text(text) => ValidationErrors::merge(result, "TextPane", text.validate()),
             Self::Container(container) => {
                 ValidationErrors::merge(result, "ContainerPane", container.validate())

--- a/matico_spec_derive/src/lib.rs
+++ b/matico_spec_derive/src/lib.rs
@@ -101,11 +101,11 @@ pub fn matico_compute(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 }
 
                 fn register_table(&mut self, table_name: &str, data: &[u8]) -> std::result::Result<(), ::matico_analysis::ArgError> {
-                    
+
                     let mut reader = ::std::io::Cursor::new(data);
                     let table = polars::prelude::IpcReader::new(reader)
                         .finish()
-                        .map_err(|e| 
+                        .map_err(|e|
                                  ::matico_analysis::ArgError::new(table_name,"Failed to register table. Is it an actualy dataframe?".into()))?;
 
                     self.tables.insert(table_name.into(),table);
@@ -143,7 +143,7 @@ pub fn matico_compute(_attr: TokenStream, input: TokenStream) -> TokenStream {
 
                let mut result_df = self.analysis.run()
                    .map_err(|e| ::wasm_bindgen::JsValue::from_serde(&e).unwrap())?;
-               
+
 
                let mut schema_vec = vec![];
 
@@ -154,7 +154,7 @@ pub fn matico_compute(_attr: TokenStream, input: TokenStream) -> TokenStream {
                     let c = col.to_arrow(0);
                     if let DataType::LargeList(_) = c.data_type(){
                         schema_vec.push(Field::new("geom",DataType::Binary,false));
-                
+
                     let geom_binary :BinaryArray::<i32> = BinaryArray::from_iter(col.list().unwrap().into_iter().
                         map(|row| {
                         let value = row.expect("Row is null");
@@ -178,7 +178,7 @@ pub fn matico_compute(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 let cursor: Cursor<Vec<u8>> = Cursor::new(vec![]);
 
                 let mut writer = FileWriter::try_new(cursor, &schema, None, WriteOptions { compression: None }).unwrap();
-                
+
                 writer.write(&chunks, None).unwrap();
                 writer.finish().unwrap();
                 let mut c = writer.into_inner();


### PR DESCRIPTION
Part of ticket: https://github.com/Matico-Platform/matico/issues/211

## Overview

Applied `cargo fmt` to the Matico project so that the code is formatted according to the default Rust spec. This formatting was done so that the code is easier to read and written according to the rules of the greater Rust community.