### PR TITLE
Fixes for Tab layouts not displaying correctly 

### DIFF
--- a/matico_components/src/Components/Layouts/MaticoTabLayout/MaticoTabLayout.tsx
+++ b/matico_components/src/Components/Layouts/MaticoTabLayout/MaticoTabLayout.tsx
@@ -130,7 +130,7 @@ export const MaticoTabLayout: React.FC<MaticoTabLayoutInterface> = ({
                 {(item) => <Item key={item.id}>{item.name}</Item>}
             </TabList>
             <View width="100%" height="100%" position={"relative"}>
-                <TabPanels>
+                <TabPanels flex={1} width="100%" height="100%">
                     {(item) => (
                         <Item key={item.id}>
                             <TabPane

--- a/matico_components/src/Components/MaticoEditor/Panes/DatasetModal.tsx
+++ b/matico_components/src/Components/MaticoEditor/Panes/DatasetModal.tsx
@@ -51,23 +51,24 @@ export const DatasetModal: React.FC<DatasetModalProps> = ({
             <Dialog width="80vw">
                 <Heading>{dataset.name}</Heading>
                 <Content>
-                    {dataset.error && <Text>{dataset.error}</Text>}
-                    {dataRequest && dataRequest.state === "Done" && (
-                        <Flex width={"100%"} gap={"size-200"} direction="row">
-                            {dataset.spec?.type === "wasmCompute" && (
-                                <View flex={1}>
-                                    <h1>Compute!</h1>
-                                    <ComputeParameterEditor
-                                        onChange={(update: any) =>
-                                            updateDataset(dataset.name, update)
-                                        }
-                                        spec={dataset.spec}
-                                    />
-                                </View>
-                            )}
-                            <DataTable data={dataRequest.result} />
-                        </Flex>
-                    )}
+                      <Flex width={"100%"} gap={"size-200"} direction="row">
+                          {dataset.spec?.type === "wasmCompute" && (
+                              <View flex={1}>
+                                  <h1>Compute!</h1>
+                                  <ComputeParameterEditor
+                                      onChange={(update: any) =>{
+                                          updateDataset(dataset.name, update)
+                                      }
+                                      }
+                                      spec={dataset.spec}
+                                  />
+                              </View>
+                          )}
+                          {dataset.error && <Text>{dataset.error}</Text>}
+                          {dataRequest && dataRequest.state === "Done" && (
+                                  <DataTable data={dataRequest.result} />
+                          )}
+                      </Flex>
                 </Content>
             </Dialog>
         </DialogTrigger>

--- a/matico_components/src/Stores/MaticoSpecSlice.tsx
+++ b/matico_components/src/Stores/MaticoSpecSlice.tsx
@@ -364,11 +364,13 @@ export const stateSlice = createSlice({
             }>
         ) => {
             const { name, datasetSpec } = action.payload;
+            console.log("Updating ", name, " With new spec ",datasetSpec)
             let datasetToUpdate = state.spec.datasets.find(
                 (d: Dataset) => d.name === name
             );
             //@ts-ignore
-            datasetToUpdate = { ...datasetToUpdate, ...datasetSpec };
+            console.log("Updating ", name, " With new spec ",datasetSpec, current(datasetToUpdate))
+            Object.assign(datasetToUpdate, datasetSpec );
         },
 
         addDatasetTransform: (

--- a/matico_components/src/Utils/paneEngine.tsx
+++ b/matico_components/src/Utils/paneEngine.tsx
@@ -68,7 +68,7 @@ export const PaneSelector: React.FC<{
 
     return (
         <>
-            <div className="grid content">
+            <div className="grid content" style={{width:'100%', height:"100%"}}>
                 <PaneComponent
                     key={normalizedPane.id}
                     position={paneRef.position}


### PR DESCRIPTION
Adds two fixes 

- After the recent layout updates, tab panes where not expanding to 100% their container, this should be resolved now
- Slight fix to get compute datasets to update from the interface when their input values change.  This still causes a complete refresh of the pane but it least works for now 