### PR TITLE
WSL / Ubuntu 22.04 Build Fix

### DIFF
--- a/matico_server/Cargo.toml
+++ b/matico_server/Cargo.toml
@@ -31,7 +31,7 @@ diesel = { version = "^1.4.4", features = ["postgres", "r2d2", "chrono", "uuid"]
 diesel_migrations = "^1.4.0"
 r2d2 = "0.8"
 chrono = { version = "0.4.10", features = ["serde"] }
-reqwest = { version = "0.11.9", features = ["json", "multipart"] }
+reqwest = { version = "0.11.9", default-features = false, features = ["blocking", "json", "multipart", "rustls-tls-native-roots"] }
 actix-rt = "1.1.1"
 jsonwebtoken = "7"
 rust-argon2 = "0.8"

--- a/matico_server/Cargo.toml
+++ b/matico_server/Cargo.toml
@@ -31,7 +31,7 @@ diesel = { version = "^1.4.4", features = ["postgres", "r2d2", "chrono", "uuid"]
 diesel_migrations = "^1.4.0"
 r2d2 = "0.8"
 chrono = { version = "0.4.10", features = ["serde"] }
-reqwest = { version = "0.11.9", default-features = false, features = ["blocking", "json", "multipart", "rustls-tls-native-roots"] }
+reqwest = { version = "0.11.9", default-features = false, features = ["json", "multipart"] }
 actix-rt = "1.1.1"
 jsonwebtoken = "7"
 rust-argon2 = "0.8"


### PR DESCRIPTION
## Overview

This PR provides a small fix for the build for Ubuntu 22.04 and WSL based systems. Ubuntu 22.04 (Jammy) based systems only have libssl/libssl-dev 3.x.x available which has a compatibility issue with a deprecated error function that rust crate Openssl calls as native C functions.

The change modifies the cargo.toml file to limit reqwest imports, and results in a successful build. The server appears to work on my end but I'd ask @stuartlynn to confirm all good before we merge in.

## Testing Instructions

* Run Matico server
* Run tests