### PR TITLE
Add rust formatting command to package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target
 node_modules
 dist/
 .cache
+.DS_Store
 
 .yarn/*
 !.yarn/cache

--- a/matico_common/src/compute/options.rs
+++ b/matico_common/src/compute/options.rs
@@ -20,8 +20,8 @@ pub struct ParameterOptionDisplayDetails {
 
 impl ParameterOptionDisplayDetails {
     pub fn new<S>(name: Option<S>, description: Option<S>) -> Self
-        where
-            S: Into<String>,
+    where
+        S: Into<String>,
     {
         ParameterOptionDisplayDetails {
             display_name: name.map(|s| s.into()),
@@ -271,7 +271,6 @@ impl ValidateParameter for BooleanOption {
         Ok(())
     }
 }
-
 
 #[derive(Serialize, Deserialize, TS)]
 #[serde(rename_all = "camelCase")]

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "deploy": "yarn predeploy && yarn run netlify deploy --prod",
     "build_rust_docs": "cargo doc --open --document-private-items --no-deps",
     "prettier-check": "yarn prettier --check '**/*.{js,ts,jsx,tsx}'",
-    "prettier-write": "yarn prettier --write '**/*.{js,ts,jsx,tsx}'"
+    "prettier-write": "yarn prettier --write '**/*.{js,ts,jsx,tsx}'",
+    "rust-format":  "cargo fmt"
   },
   "packageManager": "yarn@3.2.2",
   "dependencies": {


### PR DESCRIPTION
Issue: https://github.com/Matico-Platform/matico/issues/211

## Overview

Added a rust formatting command to the `package.json` file so that we have it available through `yarn` like we do other formatting command.

### Demo

```
michaelp@MacBook-Air-3 matico % cargo fmt
michaelp@MacBook-Air-3 matico % yarn rust-format
michaelp@MacBook-Air-3 matico % 
```
Didn't produce any errors and gave me some nicely done rust formatting.