### PR TITLE
Increasing the upload size limit for next for app api

### DIFF
--- a/matico_app_server/pages/api/apps/[id].ts
+++ b/matico_app_server/pages/api/apps/[id].ts
@@ -79,3 +79,11 @@ export default async function handler(
     }
   }
 }
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: "4mb",
+    },
+  },
+};


### PR DESCRIPTION
## Overview

Next has a body size limit on API endpoints. This was causing apps not to save when they had images in the body of the app.

Upping that limit just now till we can figure out either a better way of doing images in text panes or move to vite-plugin-ssr
